### PR TITLE
chore: update codecov image URL due to default branch change

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/electron/electron-rebuild.svg?style=svg)](https://circleci.com/gh/electron/electron-rebuild)
 [![NPM](https://img.shields.io/npm/v/electron-rebuild.svg?style=flat)](https://npm.im/electron-rebuild)
-[![Coverage Status](https://codecov.io/gh/electron/electron-rebuild/branch/master/graph/badge.svg)](https://codecov.io/gh/electron/electron-rebuild)
+[![Coverage Status](https://codecov.io/gh/electron/electron-rebuild/branch/main/graph/badge.svg)](https://codecov.io/gh/electron/electron-rebuild)
 
 This executable rebuilds native Node.js modules against the version of Node.js
 that your Electron project is using. This allows you to use native Node.js


### PR DESCRIPTION
Don't merge until the default branch changes.  AFAIK this is the only change needed.