### PR TITLE
fix: cross-platform build

### DIFF
--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -14,6 +14,7 @@ export interface RebuildOptions {
   buildPath: string;
   electronVersion: string;
   arch?: string;
+  platform?: string;
   extraModules?: string[];
   onlyModules?: string[] | null;
   force?: boolean;
@@ -48,7 +49,7 @@ export class Rebuilder implements IRebuilder {
   public lifecycle: EventEmitter;
   public buildPath: string;
   public electronVersion: string;
-  public platform: string = process.platform;
+  public platform: string;
   public arch: string;
   public force: boolean;
   public headerURL: string;
@@ -65,6 +66,7 @@ export class Rebuilder implements IRebuilder {
     this.lifecycle = options.lifecycle;
     this.buildPath = options.buildPath;
     this.electronVersion = options.electronVersion;
+    this.platform = options.platform || process.platform;
     this.arch = options.arch || process.arch;
     this.force = options.force || false;
     this.headerURL = options.headerURL || 'https://www.electronjs.org/headers';


### PR DESCRIPTION
The rebuilder has been using the hard-coded `process.platform` value as the platform attribute all this time.

This means, no matter what platform option you pass in, it would just use the current OS platform.

Basically, cross platform prebuild has not been working at all.

Combined with the electron-builder fix here https://github.com/cocktailpeanut/electron-builder/commit/73f751b42f9b7a9b636d9ae39fc340d6b2890c3b - now you can do cross platform electron builds that include prebuilt binaries.