### PR TITLE
fix: unresolved {napi_build_version}

### DIFF
--- a/src/module-type/node-gyp.ts
+++ b/src/module-type/node-gyp.ts
@@ -50,7 +50,7 @@ export class NodeGyp extends NativeModule {
 
   async buildArgsFromBinaryField(): Promise<string[]> {
     const binary = await this.packageJSONFieldWithDefault('binary', {}) as Record<string, string>;
-    let napi_build_version;
+    let napi_build_version: number = 0;
     if (binary.napi_versions) {
       napi_build_version = this.nodeAPI.getNapiVersion(binary.napi_versions)
     }

--- a/src/module-type/node-gyp.ts
+++ b/src/module-type/node-gyp.ts
@@ -50,7 +50,7 @@ export class NodeGyp extends NativeModule {
 
   async buildArgsFromBinaryField(): Promise<string[]> {
     const binary = await this.packageJSONFieldWithDefault('binary', {}) as Record<string, string>;
-    let napi_build_version: number = 0;
+    let napi_build_version: number | undefined = undefined
     if (binary.napi_versions) {
       napi_build_version = this.nodeAPI.getNapiVersion(binary.napi_versions)
     }
@@ -71,8 +71,8 @@ export class NodeGyp extends NativeModule {
         .replace('{arch}', this.rebuilder.arch)
         .replace('{version}', await this.packageJSONField('version') as string)
         .replace('{libc}', await detectLibc.family() || 'unknown');
-      if (napi_build_version) {
-        value = value.replace('{napi_build_version}', napi_build_version)
+      if (napi_build_version !== undefined) {
+        value = value.replace('{napi_build_version}', napi_build_version.toString())
       }
 
       for (const [replaceKey, replaceValue] of Object.entries(binary)) {
@@ -82,7 +82,7 @@ export class NodeGyp extends NativeModule {
       return `--${binaryKey}=${value}`;
     }))
 
-    return flags.filter(value => value) as string[];
+    return flags.filter(value => value !== undefined) as string[];
   }
 
   async rebuildModule(): Promise<void> {

--- a/src/module-type/node-gyp.ts
+++ b/src/module-type/node-gyp.ts
@@ -50,6 +50,10 @@ export class NodeGyp extends NativeModule {
 
   async buildArgsFromBinaryField(): Promise<string[]> {
     const binary = await this.packageJSONFieldWithDefault('binary', {}) as Record<string, string>;
+    let napi_build_version;
+    if (binary.napi_versions) {
+      napi_build_version = this.nodeAPI.getNapiVersion(binary.napi_versions)
+    }
     const flags = await Promise.all(Object.entries(binary).map(async ([binaryKey, binaryValue]) => {
       if (binaryKey === 'napi_versions') {
         return;
@@ -67,6 +71,9 @@ export class NodeGyp extends NativeModule {
         .replace('{arch}', this.rebuilder.arch)
         .replace('{version}', await this.packageJSONField('version') as string)
         .replace('{libc}', await detectLibc.family() || 'unknown');
+      if (napi_build_version) {
+        value = value.replace('{napi_build_version}', napi_build_version)
+      }
 
       for (const [replaceKey, replaceValue] of Object.entries(binary)) {
         value = value.replace(`{${replaceKey}}`, replaceValue);


### PR DESCRIPTION
Add code to replace {napi_build_version} with the actual build version. Originally by @Sara2009

@MarshallOfSound @Sara2009

Previously we were seeing only binaries for ARM64 on our x64 machine and this resolves that.

I have only been able to test this on x64 but presumably this should work for ARM64 as well based on what I'm seeing. I wouldn't want this to be merged if all this does it breaks ARM64 at the expense of x64 though.

(Hopefully) fixes #554
