### PR TITLE
fix: replacing macro {napi_build_version} in binary filename

### DIFF
--- a/src/module-type/node-gyp.ts
+++ b/src/module-type/node-gyp.ts
@@ -52,7 +52,7 @@ export class NodeGyp extends NativeModule {
     const binary = await this.packageJSONFieldWithDefault('binary', {}) as Record<string, string>;
     let napiBuildVersion: number | undefined = undefined
     if (Array.isArray(binary.napi_versions)) {
-      napiBuildVersion = this.nodeAPI.getNapiVersion(binary.napi_versions as number[])
+      napiBuildVersion = this.nodeAPI.getNapiVersion(binary.napi_versions.map(str => Number(str)))
     }
     const flags = await Promise.all(Object.entries(binary).map(async ([binaryKey, binaryValue]) => {
       if (binaryKey === 'napi_versions') {

--- a/src/module-type/node-gyp.ts
+++ b/src/module-type/node-gyp.ts
@@ -50,6 +50,10 @@ export class NodeGyp extends NativeModule {
 
   async buildArgsFromBinaryField(): Promise<string[]> {
     const binary = await this.packageJSONFieldWithDefault('binary', {}) as Record<string, string>;
+    let napi_build_version: number | undefined = undefined
+    if (Array.isArray(binary.napi_versions)) {
+      napi_build_version = this.nodeAPI.getNapiVersion(binary.napi_versions as number[])
+    }
     const flags = await Promise.all(Object.entries(binary).map(async ([binaryKey, binaryValue]) => {
       if (binaryKey === 'napi_versions') {
         return;
@@ -67,7 +71,9 @@ export class NodeGyp extends NativeModule {
         .replace('{arch}', this.rebuilder.arch)
         .replace('{version}', await this.packageJSONField('version') as string)
         .replace('{libc}', await detectLibc.family() || 'unknown');
-
+      if (napi_build_version !== undefined) {
+        value = value.replace('{napi_build_version}', napi_build_version.toString())
+      }
       for (const [replaceKey, replaceValue] of Object.entries(binary)) {
         value = value.replace(`{${replaceKey}}`, replaceValue);
       }

--- a/src/module-type/node-gyp.ts
+++ b/src/module-type/node-gyp.ts
@@ -50,9 +50,9 @@ export class NodeGyp extends NativeModule {
 
   async buildArgsFromBinaryField(): Promise<string[]> {
     const binary = await this.packageJSONFieldWithDefault('binary', {}) as Record<string, string>;
-    let napi_build_version: number | undefined = undefined
+    let napiBuildVersion: number | undefined = undefined
     if (Array.isArray(binary.napi_versions)) {
-      napi_build_version = this.nodeAPI.getNapiVersion(binary.napi_versions as number[])
+      napiBuildVersion = this.nodeAPI.getNapiVersion(binary.napi_versions as number[])
     }
     const flags = await Promise.all(Object.entries(binary).map(async ([binaryKey, binaryValue]) => {
       if (binaryKey === 'napi_versions') {
@@ -71,8 +71,8 @@ export class NodeGyp extends NativeModule {
         .replace('{arch}', this.rebuilder.arch)
         .replace('{version}', await this.packageJSONField('version') as string)
         .replace('{libc}', await detectLibc.family() || 'unknown');
-      if (napi_build_version !== undefined) {
-        value = value.replace('{napi_build_version}', napi_build_version.toString())
+      if (napiBuildVersion !== undefined) {
+        value = value.replace('{napi_build_version}', napiBuildVersion.toString())
       }
       for (const [replaceKey, replaceValue] of Object.entries(binary)) {
         value = value.replace(`{${replaceKey}}`, replaceValue);

--- a/test/fixture/napi-build-version/package.json
+++ b/test/fixture/napi-build-version/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "workspace-app",
+  "productName": "Workspace App",
+  "version": "1.0.0",
+  "description": "",
+  "main": "src/index.js",
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "sqlite3": "5.1.6"
+  }
+}

--- a/test/fixture/native-app1/package.json
+++ b/test/fixture/native-app1/package.json
@@ -22,8 +22,7 @@
     "farmhash": "3.2.1",
     "level": "6.0.0",
     "native-hello-world": "2.0.0",
-    "ref-napi": "1.4.2",
-    "sqlite3": "5.1.6"
+    "ref-napi": "1.4.2"
   },
   "optionalDependencies": {
     "bcrypt": "3.0.6"

--- a/test/fixture/native-app1/package.json
+++ b/test/fixture/native-app1/package.json
@@ -22,7 +22,8 @@
     "farmhash": "3.2.1",
     "level": "6.0.0",
     "native-hello-world": "2.0.0",
-    "ref-napi": "1.4.2"
+    "ref-napi": "1.4.2",
+    "sqlite3": "5.1.6"
   },
   "optionalDependencies": {
     "bcrypt": "3.0.6"

--- a/test/helpers/module-setup.ts
+++ b/test/helpers/module-setup.ts
@@ -10,6 +10,8 @@ const TIMEOUT_IN_MINUTES = process.platform === 'win32' ? 5 : 2;
 export const MINUTES_IN_MILLISECONDS = 60 * 1000;
 export const TIMEOUT_IN_MILLISECONDS = TIMEOUT_IN_MINUTES * MINUTES_IN_MILLISECONDS;
 
+export const TEST_MODULE_PATH = path.resolve(os.tmpdir(), 'electron-rebuild-test');
+
 export function resetMSVSVersion(): void {
   if (originalGypMSVSVersion) {
     process.env.GYP_MSVS_VERSION = originalGypMSVSVersion;
@@ -22,7 +24,7 @@ export async function resetTestModule(testModulePath: string, installModules = t
   const oneTimeModulePath = path.resolve(testModuleTmpPath, `${crypto.createHash('SHA1').update(testModulePath).digest('hex')}-${fixtureName}-${installModules}`);
   if (!await fs.pathExists(oneTimeModulePath)) {
     await fs.mkdir(oneTimeModulePath, { recursive: true });
-    await fs.copy(path.resolve(__dirname, `../../test/fixture/${ fixtureName }`), path.resolve(oneTimeModulePath));
+    await fs.copy(path.resolve(__dirname, `../../test/fixture/${ fixtureName }`), oneTimeModulePath);
     if (installModules) {
       await spawn('yarn', ['install'], { cwd: oneTimeModulePath });
     }

--- a/test/helpers/module-setup.ts
+++ b/test/helpers/module-setup.ts
@@ -14,12 +14,12 @@ export function resetMSVSVersion(): void {
   }
 }
 
-export async function resetTestModule(testModulePath: string, installModules = true): Promise<void> {
+export async function resetTestModule(testModulePath: string, installModules = true, fixtureName = 'native-app1'): Promise<void> {
   await fs.remove(testModulePath);
   await fs.mkdir(testModulePath, { recursive: true });
-  await fs.copyFile(
-    path.resolve(__dirname, '../../test/fixture/native-app1/package.json'),
-    path.resolve(testModulePath, 'package.json')
+  await fs.copy(
+    path.resolve(__dirname, `../../test/fixture/${ fixtureName }`),
+    path.resolve(testModulePath)
   );
   if (installModules) {
     await spawn('yarn', ['install'], { cwd: testModulePath });

--- a/test/helpers/module-setup.ts
+++ b/test/helpers/module-setup.ts
@@ -22,7 +22,7 @@ export async function resetTestModule(testModulePath: string, installModules = t
   const oneTimeModulePath = path.resolve(testModuleTmpPath, `${crypto.createHash('SHA1').update(testModulePath).digest('hex')}-${installModules}`);
   if (!await fs.pathExists(oneTimeModulePath)) {
     await fs.mkdir(oneTimeModulePath, { recursive: true });
-    await fs.copy(path.resolve(__dirname, `../../test/fixture/${ fixtureName }`), oneTimeModulePath);
+    await fs.copy(path.resolve(__dirname, `../../test/fixture/${ fixtureName }`), path.resolve(oneTimeModulePath));
     if (installModules) {
       await spawn('yarn', ['install'], { cwd: oneTimeModulePath });
     }

--- a/test/helpers/module-setup.ts
+++ b/test/helpers/module-setup.ts
@@ -19,7 +19,7 @@ export function resetMSVSVersion(): void {
 const testModuleTmpPath = fs.mkdtempSync(path.resolve(os.tmpdir(), 'e-r-test-module-'));
 
 export async function resetTestModule(testModulePath: string, installModules = true, fixtureName = 'native-app1'): Promise<void> {
-  const oneTimeModulePath = path.resolve(testModuleTmpPath, `${crypto.createHash('SHA1').update(testModulePath).digest('hex')}-${installModules}`);
+  const oneTimeModulePath = path.resolve(testModuleTmpPath, `${crypto.createHash('SHA1').update(testModulePath).digest('hex')}-${fixtureName}-${installModules}`);
   if (!await fs.pathExists(oneTimeModulePath)) {
     await fs.mkdir(oneTimeModulePath, { recursive: true });
     await fs.copy(path.resolve(__dirname, `../../test/fixture/${ fixtureName }`), path.resolve(oneTimeModulePath));

--- a/test/module-type-node-gyp.ts
+++ b/test/module-type-node-gyp.ts
@@ -1,15 +1,12 @@
 import { EventEmitter } from 'events';
 import { expect } from 'chai';
-import os from 'os';
-import path from 'path';
 
-import { cleanupTestModule, resetTestModule } from './helpers/module-setup';
+import { cleanupTestModule, resetTestModule, TEST_MODULE_PATH as testModulePath } from './helpers/module-setup';
 import { NodeGyp } from '../lib/module-type/node-gyp/node-gyp';
 import { Rebuilder } from '../lib/rebuild';
 
 describe('node-gyp', () => {
   describe('buildArgs', () => {
-    const testModulePath = path.resolve(os.tmpdir(), 'electron-rebuild-test');
 
     before(async () => await resetTestModule(testModulePath, false));
     after(async () => await cleanupTestModule(testModulePath));

--- a/test/module-type-prebuild-install.ts
+++ b/test/module-type-prebuild-install.ts
@@ -1,16 +1,13 @@
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { EventEmitter } from 'events';
-import os from 'os';
 import path from 'path';
 
-import { cleanupTestModule, resetTestModule, TIMEOUT_IN_MILLISECONDS } from './helpers/module-setup';
+import { cleanupTestModule, resetTestModule, TIMEOUT_IN_MILLISECONDS, TEST_MODULE_PATH as testModulePath } from './helpers/module-setup';
 import { PrebuildInstall } from '../lib/module-type/prebuild-install';
 import { Rebuilder } from '../lib/rebuild';
 
 chai.use(chaiAsPromised);
-
-const testModulePath = path.resolve(os.tmpdir(), 'electron-rebuild-test');
 
 describe('prebuild-install', () => {
   const modulePath = path.join(testModulePath, 'node_modules', 'farmhash');

--- a/test/rebuild-napibuildversion.ts
+++ b/test/rebuild-napibuildversion.ts
@@ -36,7 +36,7 @@ describe('rebuild with napi_build_versions in binary config', async function () 
       });
       await expectNativeModuleToBeRebuilt(testModulePath, 'sqlite3');
 
-      const dirname = path.dirname(binaryPath)
+      const dirname = path.dirname(path.dirname(binaryPath))
       console.log(dirname);
       fs.readdirSync(dirname).forEach(file => {
         console.log(file);

--- a/test/rebuild-napibuildversion.ts
+++ b/test/rebuild-napibuildversion.ts
@@ -24,7 +24,7 @@ describe('rebuild with napi_build_versions in binary config', async function () 
   // https://github.com/electron/rebuild/issues/554
   const archs = ['x64', 'arm64']
   for (const arch of archs) {
-    it(`${ arch } arch should have rebuilt bianry with napi_build_versions array provided`, async () => {
+    it(`${ arch } arch should have rebuilt bianry with 'napi_build_versions' array and 'libc' provided`, async () => {
       const libc = await detectLibc.family() || 'unknown';
       const binaryPath = napiBuildVersionSpecificPath(arch, libc)
       if (await fs.pathExists(binaryPath)) {
@@ -40,12 +40,6 @@ describe('rebuild with napi_build_versions in binary config', async function () 
         arch
       });
       await expectNativeModuleToBeRebuilt(testModulePath, 'sqlite3');
-
-      const dirname = path.dirname(path.dirname(binaryPath))
-      console.log(dirname);
-      fs.readdirSync(dirname).forEach(file => {
-        console.log(file);
-      });
 
       expect(await fs.pathExists(binaryPath)).to.be.true;
       fs.removeSync(binaryPath);

--- a/test/rebuild-napibuildversion.ts
+++ b/test/rebuild-napibuildversion.ts
@@ -6,6 +6,7 @@ import { rebuild } from '../lib/rebuild';
 import { getExactElectronVersionSync } from './helpers/electron-version';
 import { TIMEOUT_IN_MILLISECONDS, TEST_MODULE_PATH as testModulePath, cleanupTestModule, resetTestModule } from './helpers/module-setup';
 import { expectNativeModuleToBeRebuilt } from './helpers/rebuild';
+import detectLibc from 'detect-libc';
 
 const testElectronVersion = getExactElectronVersionSync();
 
@@ -26,10 +27,9 @@ describe('rebuild with napi_build_versions in binary config', async function () 
   const archs = ['x64', 'arm64']
   for (const arch of archs) {
     it(`${ arch } arch should have rebuilt bianry with 'napi_build_versions' array and 'libc' provided`, async () => {
-      // Should use detect-libc but for some reason it causes the test suite to not even run
-      const libc = process.platform === 'darwin' ? 'unknown' : 'glibc'
-      
+      const libc = await detectLibc.family() || 'unknown'
       const binaryPath = napiBuildVersionSpecificPath(arch, libc)
+      
       if (await fs.pathExists(binaryPath)) {
         fs.removeSync(binaryPath)
       }

--- a/test/rebuild-napibuildversion.ts
+++ b/test/rebuild-napibuildversion.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import detectLibc from 'detect-libc';
 
 import { expect } from 'chai';
-import { rebuild } from '../src/rebuild';
+import { rebuild } from '../lib/rebuild';
 import { getExactElectronVersionSync } from './helpers/electron-version';
 import { TIMEOUT_IN_MILLISECONDS, cleanupTestModule, resetTestModule } from './helpers/module-setup';
 import { expectNativeModuleToBeRebuilt } from './helpers/rebuild';

--- a/test/rebuild-napibuildversion.ts
+++ b/test/rebuild-napibuildversion.ts
@@ -1,0 +1,44 @@
+import * as fs from 'fs-extra';
+import * as os from 'os';
+import * as path from 'path';
+
+import { expect } from 'chai';
+import { rebuild } from '../src/rebuild';
+import { getExactElectronVersionSync } from './helpers/electron-version';
+import { TIMEOUT_IN_MILLISECONDS, cleanupTestModule, resetTestModule } from './helpers/module-setup';
+import { expectNativeModuleToBeRebuilt } from './helpers/rebuild';
+
+const testElectronVersion = getExactElectronVersionSync();
+
+describe('rebuild with napi_build_versions in binary config', async function () {
+  this.timeout(TIMEOUT_IN_MILLISECONDS);
+  const testModulePath = path.resolve(os.tmpdir(), 'electron-rebuild-test');
+  const napiBuildVersion = 6;
+  const napiBuildVersionSpecificPath = (arch: string) => path.resolve(testModulePath, `node_modules/sqlite3/lib/binding/napi-v${ napiBuildVersion }-${ process.platform }-unknown-${ arch }/node_sqlite3.node`);
+
+  before(() => resetTestModule(testModulePath, true, 'napi-build-version'));
+  after(() => cleanupTestModule(testModulePath));
+
+  // https://github.com/electron/rebuild/issues/554
+  const archs = ['x64', 'arm64']
+  for (const arch of archs) {
+    it(`${ arch } arch should have rebuilt bianry with napi_build_versions array provided`, async () => {
+      const binaryPath = napiBuildVersionSpecificPath(arch)
+      if (await fs.pathExists(binaryPath)) {
+        fs.removeSync(binaryPath)
+      }
+      expect(await fs.pathExists(binaryPath)).to.be.false;
+
+      await rebuild({
+        buildPath: testModulePath,
+        electronVersion: testElectronVersion,
+        arch
+      });
+      await expectNativeModuleToBeRebuilt(testModulePath, 'sqlite3');
+
+      expect(await fs.pathExists(binaryPath)).to.be.true;
+      fs.removeSync(binaryPath);
+    });
+  }
+
+});

--- a/test/rebuild-napibuildversion.ts
+++ b/test/rebuild-napibuildversion.ts
@@ -1,7 +1,6 @@
 import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
-import detectLibc from 'detect-libc';
 
 import { expect } from 'chai';
 import { rebuild } from '../lib/rebuild';
@@ -25,7 +24,9 @@ describe('rebuild with napi_build_versions in binary config', async function () 
   const archs = ['x64', 'arm64']
   for (const arch of archs) {
     it(`${ arch } arch should have rebuilt bianry with 'napi_build_versions' array and 'libc' provided`, async () => {
-      const libc = await detectLibc.family() || 'unknown';
+      // Should use detect-libc but for some reason it causes the test suite to not even run
+      const libc = process.platform === 'darwin' ? 'unknown' : 'glibc'
+      
       const binaryPath = napiBuildVersionSpecificPath(arch, libc)
       if (await fs.pathExists(binaryPath)) {
         fs.removeSync(binaryPath)

--- a/test/rebuild-napibuildversion.ts
+++ b/test/rebuild-napibuildversion.ts
@@ -1,18 +1,16 @@
 import * as fs from 'fs-extra';
-import * as os from 'os';
 import * as path from 'path';
 
 import { expect } from 'chai';
 import { rebuild } from '../lib/rebuild';
 import { getExactElectronVersionSync } from './helpers/electron-version';
-import { TIMEOUT_IN_MILLISECONDS, cleanupTestModule, resetTestModule } from './helpers/module-setup';
+import { TIMEOUT_IN_MILLISECONDS, TEST_MODULE_PATH as testModulePath, cleanupTestModule, resetTestModule } from './helpers/module-setup';
 import { expectNativeModuleToBeRebuilt } from './helpers/rebuild';
 
 const testElectronVersion = getExactElectronVersionSync();
 
 describe('rebuild with napi_build_versions in binary config', async function () {
   this.timeout(TIMEOUT_IN_MILLISECONDS);
-  const testModulePath = path.resolve(os.tmpdir(), 'electron-rebuild-test');
 
   const napiBuildVersion = 6;
   const napiBuildVersionSpecificPath = (arch: string, libc: string) => path.resolve(testModulePath, `node_modules/sqlite3/lib/binding/napi-v${ napiBuildVersion }-${ process.platform }-${ libc }-${ arch }/node_sqlite3.node`);

--- a/test/rebuild-napibuildversion.ts
+++ b/test/rebuild-napibuildversion.ts
@@ -36,6 +36,12 @@ describe('rebuild with napi_build_versions in binary config', async function () 
       });
       await expectNativeModuleToBeRebuilt(testModulePath, 'sqlite3');
 
+      const dirname = path.dirname(binaryPath)
+      console.log(dirname);
+      fs.readdirSync(dirname).forEach(file => {
+        console.log(file);
+      });
+
       expect(await fs.pathExists(binaryPath)).to.be.true;
       fs.removeSync(binaryPath);
     });

--- a/test/rebuild-napibuildversion.ts
+++ b/test/rebuild-napibuildversion.ts
@@ -17,7 +17,11 @@ describe('rebuild with napi_build_versions in binary config', async function () 
   const napiBuildVersion = 6;
   const napiBuildVersionSpecificPath = (arch: string, libc: string) => path.resolve(testModulePath, `node_modules/sqlite3/lib/binding/napi-v${ napiBuildVersion }-${ process.platform }-${ libc }-${ arch }/node_sqlite3.node`);
 
-  before(() => resetTestModule(testModulePath, true, 'napi-build-version'));
+  before(async () => {
+    await resetTestModule(testModulePath, true, 'napi-build-version')
+    // Forcing `msvs_version` needed in order for `arm64` `win32` binary to be built
+    process.env.GYP_MSVS_VERSION = "2019"
+  });
   after(() => cleanupTestModule(testModulePath));
 
   // https://github.com/electron/rebuild/issues/554
@@ -33,17 +37,14 @@ describe('rebuild with napi_build_versions in binary config', async function () 
       }
       expect(await fs.pathExists(binaryPath)).to.be.false;
 
-      // Forcing `msvs_version` needed in order for `arm64` `win32` binary to be built
-      process.env.GYP_MSVS_VERSION = "2019"
       await rebuild({
         buildPath: testModulePath,
         electronVersion: testElectronVersion,
         arch
       });
+      
       await expectNativeModuleToBeRebuilt(testModulePath, 'sqlite3');
-
       expect(await fs.pathExists(binaryPath)).to.be.true;
-      fs.removeSync(binaryPath);
     });
   }
 

--- a/test/rebuild-yarnworkspace.ts
+++ b/test/rebuild-yarnworkspace.ts
@@ -1,30 +1,21 @@
-import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as os from 'os';
-import { spawn } from '@malept/cross-spawn-promise';
 
 import { expectNativeModuleToBeRebuilt, expectNativeModuleToNotBeRebuilt } from './helpers/rebuild';
 import { getExactElectronVersionSync } from './helpers/electron-version';
 import { getProjectRootPath } from '../lib/search-module';
 import { rebuild } from '../lib/rebuild';
+import { cleanupTestModule, resetTestModule } from './helpers/module-setup';
 
 const testElectronVersion = getExactElectronVersionSync();
 
 describe('rebuild for yarn workspace', function() {
   this.timeout(2 * 60 * 1000);
   const testModulePath = path.resolve(os.tmpdir(), 'electron-rebuild-test');
-  const msvs_version: string | undefined = process.env.GYP_MSVS_VERSION;
 
   describe('core behavior', () => {
     before(async () => {
-      await fs.remove(testModulePath);
-      await fs.copy(path.resolve(__dirname, 'fixture/workspace-test'), testModulePath);
-
-      await spawn('yarn', [], { cwd: testModulePath });
-      if (msvs_version) {
-        process.env.GYP_MSVS_VERSION = msvs_version;
-      }
-
+      await resetTestModule(testModulePath, true, 'workspace-test')
       const projectRootPath = await getProjectRootPath(path.join(testModulePath, 'workspace-test', 'child-workspace'));
 
       await rebuild({
@@ -34,6 +25,7 @@ describe('rebuild for yarn workspace', function() {
         projectRootPath
       });
     });
+    after(() => cleanupTestModule(testModulePath));
 
     it('should have rebuilt top level prod dependencies', async () => {
       await expectNativeModuleToBeRebuilt(testModulePath, 'snappy');
@@ -41,13 +33,6 @@ describe('rebuild for yarn workspace', function() {
 
     it('should not have rebuilt top level devDependencies', async () => {
       await expectNativeModuleToNotBeRebuilt(testModulePath, 'sleep');
-    });
-
-    after(async () => {
-      await fs.remove(testModulePath);
-      if (msvs_version) {
-        process.env.GYP_MSVS_VERSION = msvs_version;
-      }
     });
   });
 });

--- a/test/rebuild-yarnworkspace.ts
+++ b/test/rebuild-yarnworkspace.ts
@@ -1,30 +1,22 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as os from 'os';
-import { spawn } from '@malept/cross-spawn-promise';
 
 import { expectNativeModuleToBeRebuilt, expectNativeModuleToNotBeRebuilt } from './helpers/rebuild';
 import { getExactElectronVersionSync } from './helpers/electron-version';
 import { getProjectRootPath } from '../src/search-module';
 import { rebuild } from '../src/rebuild';
+import { MINUTES_IN_MILLISECONDS, cleanupTestModule, resetTestModule } from './helpers/module-setup';
 
 const testElectronVersion = getExactElectronVersionSync();
 
 describe('rebuild for yarn workspace', function() {
-  this.timeout(2 * 60 * 1000);
+  this.timeout(10 * MINUTES_IN_MILLISECONDS);
   const testModulePath = path.resolve(os.tmpdir(), 'electron-rebuild-test');
-  const msvs_version: string | undefined = process.env.GYP_MSVS_VERSION;
 
   describe('core behavior', () => {
     before(async () => {
-      await fs.remove(testModulePath);
-      await fs.copy(path.resolve(__dirname, 'fixture/workspace-test'), testModulePath);
-
-      await spawn('yarn', [], { cwd: testModulePath });
-      if (msvs_version) {
-        process.env.GYP_MSVS_VERSION = msvs_version;
-      }
-
+      await resetTestModule(testModulePath, true, 'workspace-test')
       const projectRootPath = await getProjectRootPath(path.join(testModulePath, 'workspace-test', 'child-workspace'));
 
       await rebuild({
@@ -34,6 +26,7 @@ describe('rebuild for yarn workspace', function() {
         projectRootPath
       });
     });
+    after(() => cleanupTestModule(testModulePath));
 
     it('should have rebuilt top level prod dependencies', async () => {
       await expectNativeModuleToBeRebuilt(testModulePath, 'snappy');
@@ -41,13 +34,6 @@ describe('rebuild for yarn workspace', function() {
 
     it('should not have rebuilt top level devDependencies', async () => {
       await expectNativeModuleToNotBeRebuilt(testModulePath, 'sleep');
-    });
-
-    after(async () => {
-      await fs.remove(testModulePath);
-      if (msvs_version) {
-        process.env.GYP_MSVS_VERSION = msvs_version;
-      }
     });
   });
 });

--- a/test/rebuild-yarnworkspace.ts
+++ b/test/rebuild-yarnworkspace.ts
@@ -1,4 +1,3 @@
-import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as os from 'os';
 

--- a/test/rebuild-yarnworkspace.ts
+++ b/test/rebuild-yarnworkspace.ts
@@ -1,12 +1,12 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as os from 'os';
-import { spawn } from '@malept/cross-spawn-promise';
 
 import { expectNativeModuleToBeRebuilt, expectNativeModuleToNotBeRebuilt } from './helpers/rebuild';
 import { getExactElectronVersionSync } from './helpers/electron-version';
 import { getProjectRootPath } from '../lib/search-module';
 import { rebuild } from '../lib/rebuild';
+import { resetTestModule } from './helpers/module-setup';
 
 const testElectronVersion = getExactElectronVersionSync();
 
@@ -17,14 +17,7 @@ describe('rebuild for yarn workspace', function() {
 
   describe('core behavior', () => {
     before(async () => {
-      await fs.remove(testModulePath);
-      await fs.copy(path.resolve(__dirname, 'fixture/workspace-test'), testModulePath);
-
-      await spawn('yarn', [], { cwd: testModulePath });
-      if (msvs_version) {
-        process.env.GYP_MSVS_VERSION = msvs_version;
-      }
-
+      await resetTestModule(testModulePath, true, 'workspace-test')
       const projectRootPath = await getProjectRootPath(path.join(testModulePath, 'workspace-test', 'child-workspace'));
 
       await rebuild({

--- a/test/rebuild-yarnworkspace.ts
+++ b/test/rebuild-yarnworkspace.ts
@@ -1,17 +1,15 @@
 import * as path from 'path';
-import * as os from 'os';
 
 import { expectNativeModuleToBeRebuilt, expectNativeModuleToNotBeRebuilt } from './helpers/rebuild';
 import { getExactElectronVersionSync } from './helpers/electron-version';
 import { getProjectRootPath } from '../lib/search-module';
 import { rebuild } from '../lib/rebuild';
-import { cleanupTestModule, resetTestModule } from './helpers/module-setup';
+import { TIMEOUT_IN_MILLISECONDS, TEST_MODULE_PATH as testModulePath, cleanupTestModule, resetTestModule } from './helpers/module-setup';
 
 const testElectronVersion = getExactElectronVersionSync();
 
 describe('rebuild for yarn workspace', function() {
-  this.timeout(2 * 60 * 1000);
-  const testModulePath = path.resolve(os.tmpdir(), 'electron-rebuild-test');
+  this.timeout(TIMEOUT_IN_MILLISECONDS);
 
   describe('core behavior', () => {
     before(async () => {

--- a/test/rebuild-yarnworkspace.ts
+++ b/test/rebuild-yarnworkspace.ts
@@ -1,4 +1,3 @@
-import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as os from 'os';
 
@@ -6,14 +5,13 @@ import { expectNativeModuleToBeRebuilt, expectNativeModuleToNotBeRebuilt } from 
 import { getExactElectronVersionSync } from './helpers/electron-version';
 import { getProjectRootPath } from '../lib/search-module';
 import { rebuild } from '../lib/rebuild';
-import { resetTestModule } from './helpers/module-setup';
+import { cleanupTestModule, resetTestModule } from './helpers/module-setup';
 
 const testElectronVersion = getExactElectronVersionSync();
 
 describe('rebuild for yarn workspace', function() {
   this.timeout(2 * 60 * 1000);
   const testModulePath = path.resolve(os.tmpdir(), 'electron-rebuild-test');
-  const msvs_version: string | undefined = process.env.GYP_MSVS_VERSION;
 
   describe('core behavior', () => {
     before(async () => {
@@ -27,6 +25,7 @@ describe('rebuild for yarn workspace', function() {
         projectRootPath
       });
     });
+    after(() => cleanupTestModule(testModulePath));
 
     it('should have rebuilt top level prod dependencies', async () => {
       await expectNativeModuleToBeRebuilt(testModulePath, 'snappy');
@@ -34,13 +33,6 @@ describe('rebuild for yarn workspace', function() {
 
     it('should not have rebuilt top level devDependencies', async () => {
       await expectNativeModuleToNotBeRebuilt(testModulePath, 'sleep');
-    });
-
-    after(async () => {
-      await fs.remove(testModulePath);
-      if (msvs_version) {
-        process.env.GYP_MSVS_VERSION = msvs_version;
-      }
     });
   });
 });

--- a/test/rebuild-yarnworkspace.ts
+++ b/test/rebuild-yarnworkspace.ts
@@ -1,21 +1,30 @@
+import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as os from 'os';
+import { spawn } from '@malept/cross-spawn-promise';
 
 import { expectNativeModuleToBeRebuilt, expectNativeModuleToNotBeRebuilt } from './helpers/rebuild';
 import { getExactElectronVersionSync } from './helpers/electron-version';
 import { getProjectRootPath } from '../lib/search-module';
 import { rebuild } from '../lib/rebuild';
-import { cleanupTestModule, resetTestModule } from './helpers/module-setup';
 
 const testElectronVersion = getExactElectronVersionSync();
 
 describe('rebuild for yarn workspace', function() {
   this.timeout(2 * 60 * 1000);
   const testModulePath = path.resolve(os.tmpdir(), 'electron-rebuild-test');
+  const msvs_version: string | undefined = process.env.GYP_MSVS_VERSION;
 
   describe('core behavior', () => {
     before(async () => {
-      await resetTestModule(testModulePath, true, 'workspace-test')
+      await fs.remove(testModulePath);
+      await fs.copy(path.resolve(__dirname, 'fixture/workspace-test'), testModulePath);
+
+      await spawn('yarn', [], { cwd: testModulePath });
+      if (msvs_version) {
+        process.env.GYP_MSVS_VERSION = msvs_version;
+      }
+
       const projectRootPath = await getProjectRootPath(path.join(testModulePath, 'workspace-test', 'child-workspace'));
 
       await rebuild({
@@ -25,7 +34,6 @@ describe('rebuild for yarn workspace', function() {
         projectRootPath
       });
     });
-    after(() => cleanupTestModule(testModulePath));
 
     it('should have rebuilt top level prod dependencies', async () => {
       await expectNativeModuleToBeRebuilt(testModulePath, 'snappy');
@@ -33,6 +41,13 @@ describe('rebuild for yarn workspace', function() {
 
     it('should not have rebuilt top level devDependencies', async () => {
       await expectNativeModuleToNotBeRebuilt(testModulePath, 'sleep');
+    });
+
+    after(async () => {
+      await fs.remove(testModulePath);
+      if (msvs_version) {
+        process.env.GYP_MSVS_VERSION = msvs_version;
+      }
     });
   });
 });

--- a/test/rebuild.ts
+++ b/test/rebuild.ts
@@ -1,9 +1,8 @@
 import { expect } from 'chai';
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import * as os from 'os';
 
-import { cleanupTestModule, MINUTES_IN_MILLISECONDS, resetMSVSVersion, resetTestModule, TIMEOUT_IN_MILLISECONDS } from './helpers/module-setup';
+import { cleanupTestModule, MINUTES_IN_MILLISECONDS, TEST_MODULE_PATH as testModulePath, resetMSVSVersion, resetTestModule, TIMEOUT_IN_MILLISECONDS } from './helpers/module-setup';
 import { expectNativeModuleToBeRebuilt, expectNativeModuleToNotBeRebuilt } from './helpers/rebuild';
 import { getExactElectronVersionSync } from './helpers/electron-version';
 import { rebuild } from '../lib/rebuild';
@@ -11,7 +10,6 @@ import { rebuild } from '../lib/rebuild';
 const testElectronVersion = getExactElectronVersionSync();
 
 describe('rebuilder', () => {
-  const testModulePath = path.resolve(os.tmpdir(), 'electron-rebuild-test');
 
   describe('core behavior', function() {
     this.timeout(TIMEOUT_IN_MILLISECONDS);

--- a/test/rebuild.ts
+++ b/test/rebuild.ts
@@ -194,35 +194,4 @@ describe('rebuilder', () => {
       await expectNativeModuleToBeRebuilt(testModulePath, 'ffi-napi');
     });
   });
-
-  describe('rebuild with napi_build_versions in binary config', async function () {
-    this.timeout(10 * MINUTES_IN_MILLISECONDS);
-
-    before(async () => await resetTestModule(testModulePath));
-    after(async() => await cleanupTestModule(testModulePath));
-
-    // https://github.com/electron/rebuild/issues/554
-    const archs = ['x64', 'arm64']
-    for (const arch of archs) {
-      it(`${ arch } arch should have rebuilt bianry with napi_build_versions array provided`, async () => {
-        const napiBuildVersion = 6;
-        const binaryPath = path.resolve(testModulePath, `node_modules/sqlite3/lib/binding/napi-v${ napiBuildVersion }-${ process.platform }-unknown-${ arch }/node_sqlite3.node`);
-        if (await fs.pathExists(binaryPath)) {
-          fs.removeSync(binaryPath)
-        }
-        expect(await fs.pathExists(binaryPath)).to.be.false;
-
-        await rebuild({
-          buildPath: testModulePath,
-          electronVersion: testElectronVersion,
-          arch,
-          onlyModules: ['sqlite3'],
-        });
-        await expectNativeModuleToBeRebuilt(testModulePath, 'sqlite3');
-
-        expect(await fs.pathExists(binaryPath)).to.be.true;
-        fs.removeSync(binaryPath);
-      });
-    }
-  });
 });

--- a/test/rebuild.ts
+++ b/test/rebuild.ts
@@ -194,4 +194,35 @@ describe('rebuilder', () => {
       await expectNativeModuleToBeRebuilt(testModulePath, 'ffi-napi');
     });
   });
+
+  describe('rebuild with napi_build_versions in binary config', async function () {
+    this.timeout(10 * MINUTES_IN_MILLISECONDS);
+
+    before(async () => await resetTestModule(testModulePath));
+    after(async() => await cleanupTestModule(testModulePath));
+
+    // https://github.com/electron/rebuild/issues/554
+    const archs = ['x64', 'arm64']
+    for (const arch of archs) {
+      it(`${ arch } arch should have rebuilt bianry with napi_build_versions array provided`, async () => {
+        const napiBuildVersion = 6;
+        const binaryPath = path.resolve(testModulePath, `node_modules/sqlite3/lib/binding/napi-v${ napiBuildVersion }-${ process.platform }-unknown-${ arch }/node_sqlite3.node`);
+        if (await fs.pathExists(binaryPath)) {
+          fs.removeSync(binaryPath)
+        }
+        expect(await fs.pathExists(binaryPath)).to.be.false;
+
+        await rebuild({
+          buildPath: testModulePath,
+          electronVersion: testElectronVersion,
+          arch,
+          onlyModules: ['sqlite3'],
+        });
+        await expectNativeModuleToBeRebuilt(testModulePath, 'sqlite3');
+
+        expect(await fs.pathExists(binaryPath)).to.be.true;
+        fs.removeSync(binaryPath);
+      });
+    }
+  });
 });


### PR DESCRIPTION
fix: replacing macro `{napi_build_version}` in binary filename by using `binary.napi_build_versions` in package.json. Fixes: #554

Added unit test for offending module: `"sqlite3": "5.1.6"`

Tested on mac for arm64 and x64 rebuilds

Related:
https://github.com/electron-userland/electron-builder/issues/7473

Original PR credit to https://github.com/electron/rebuild/pull/1076 (I just added tests as requested)
