### PR TITLE
perf: use worker processes for node-gyp rebuilds

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@electron/rebuild",
   "version": "0.0.0-development",
   "description": "Electron supporting package to rebuild native node modules against the currently installed electron",
-  "main": "lib/src/main.js",
-  "typings": "lib/src/main.d.ts",
+  "main": "lib/main.js",
+  "typings": "lib/main.d.ts",
   "scripts": {
     "codecov": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "compile": "tsc",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepare": "npm run compile",
     "mocha": "cross-env TS_NODE_FILES=true mocha",
     "lint": "eslint --ext .ts .",
-    "spec": "npm run mocha -- test/*.ts",
+    "spec": "tsc && npm run mocha -- test/*.ts",
     "test": "npm run lint && npm run spec"
   },
   "bin": {

--- a/src/clang-fetcher.ts
+++ b/src/clang-fetcher.ts
@@ -2,7 +2,6 @@ import * as cp from 'child_process';
 import debug from 'debug';
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import semver from 'semver';
 import * as tar from 'tar';
 import * as zlib from 'zlib';
 import { ELECTRON_GYP_DIR } from './constants';
@@ -37,13 +36,9 @@ export async function getClangEnvironmentVars(electronVersion: string, targetArc
   const clangDownloadDir = await downloadClangVersion(electronVersion);
 
   const clangDir = path.resolve(clangDownloadDir, 'bin');
-  const cxxflags = [];
   const clangArgs: string[] = [];
   if (process.platform === 'darwin') {
     clangArgs.push('-isysroot', getSDKRoot());
-  }
-  if (semver.major(electronVersion) >= 20) {
-    cxxflags.push('-std=c++17');
   }
 
   const gypArgs = [];
@@ -61,7 +56,6 @@ export async function getClangEnvironmentVars(electronVersion: string, targetArc
     env: {
       CC: `"${path.resolve(clangDir, 'clang')}" ${clangArgs.join(' ')}`,
       CXX: `"${path.resolve(clangDir, 'clang++')}" ${clangArgs.join(' ')}`,
-      CXXFLAGS: `${cxxflags.join(' ')}`
     },
     args: gypArgs,
   }

--- a/src/module-rebuilder.ts
+++ b/src/module-rebuilder.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 
 import { cacheModuleState } from './cache';
-import { NodeGyp } from './module-type/node-gyp';
+import { NodeGyp } from './module-type/node-gyp/node-gyp';
 import { Prebuildify } from './module-type/prebuildify';
 import { PrebuildInstall } from './module-type/prebuild-install';
 import { IRebuilder } from './types';

--- a/src/module-type/node-gyp/node-gyp.ts
+++ b/src/module-type/node-gyp/node-gyp.ts
@@ -1,13 +1,12 @@
 import debug from 'debug';
 import detectLibc from 'detect-libc';
-import NodeGypRunner from 'node-gyp';
 import path from 'path';
-import { promisify } from 'util';
 import semver from 'semver';
 
-import { ELECTRON_GYP_DIR } from '../constants';
-import { getClangEnvironmentVars } from '../clang-fetcher';
-import { NativeModule } from '.';
+import { ELECTRON_GYP_DIR } from '../../constants';
+import { getClangEnvironmentVars } from '../../clang-fetcher';
+import { NativeModule } from '..';
+import { fork } from 'child_process';
 
 const d = debug('electron-rebuild');
 
@@ -86,76 +85,45 @@ export class NodeGyp extends NativeModule {
       // throw new Error(`node-gyp does not support building modules with spaces in their path, tried to build: ${modulePath}`);
     }
 
-    let env: Record<string, string | undefined>;
+    const env = {
+      ...process.env,
+    };
     const extraNodeGypArgs: string[] = [];
 
-    if (semver.major(this.rebuilder.electronVersion) >= 20) {
-      process.env.CXXFLAGS = '-std=c++17';
-    }
-
     if (this.rebuilder.useElectronClang) {
-      env = { ...process.env };
       const { env: clangEnv, args: clangArgs } = await getClangEnvironmentVars(this.rebuilder.electronVersion, this.rebuilder.arch);
-      Object.assign(process.env, clangEnv);
+      Object.assign(env, clangEnv);
       extraNodeGypArgs.push(...clangArgs);
     }
 
     const nodeGypArgs = await this.buildArgs(extraNodeGypArgs);
     d('rebuilding', this.moduleName, 'with args', nodeGypArgs);
 
-    const nodeGyp = NodeGypRunner();
-    nodeGyp.parseArgv(nodeGypArgs);
-    nodeGyp.devDir = ELECTRON_GYP_DIR;
-    let command = nodeGyp.todo.shift();
-    const originalWorkingDir = process.cwd();
-    try {
-      process.chdir(this.modulePath);
-      while (command) {
-        if (command.name === 'configure') {
-          command.args = command.args.filter((arg: string) => !extraNodeGypArgs.includes(arg));
-        } else if (command.name === 'build' && process.platform === 'win32') {
-          // This is disgusting but it prevents node-gyp from destroying our MSBuild arguments
-          command.args.map = (fn: (arg: string) => string) => {
-            return Array.prototype.map.call(command.args, (arg: string) => {
-              if (arg.startsWith('/p:')) return arg;
-              return fn(arg);
-            });
-          }
-        }
-        await promisify(nodeGyp.commands[command.name])(command.args);
-        command = nodeGyp.todo.shift();
-      }
-    } catch (err) {
-      const errorMessage = `node-gyp failed to rebuild '${this.modulePath}'.
-For more information, rerun with the DEBUG environment variable set to "electron-rebuild".
+    const forkedChild = fork(path.resolve(__dirname, 'worker.js'), {
+      env,
+      cwd: this.modulePath,
+      stdio: 'pipe',
+    });
+    const outputBuffers: Buffer[] = [];
+    forkedChild.stdout?.on('data', (chunk) => {
+      outputBuffers.push(chunk);
+    });
+    forkedChild.stderr?.on('data', (chunk) => {
+      outputBuffers.push(chunk);
+    });
+    forkedChild.send({
+      moduleName: this.moduleName,
+      nodeGypArgs,
+      extraNodeGypArgs,
+      devDir: ELECTRON_GYP_DIR,
+    });
 
-Error: ${err.message || err}\n\n`;
-      throw new Error(errorMessage);
-    } finally {
-      process.chdir(originalWorkingDir);
-    }
-
-    if (this.rebuilder.useElectronClang) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this.restoreEnv(env!);
-    }
-  }
-
-  private restoreEnv(env: Record<string, string | undefined>): void {
-    const gotKeys = new Set<string>(Object.keys(process.env));
-    const expectedKeys = new Set<string>(Object.keys(env));
-
-    for (const key of Object.keys(process.env)) {
-      if (!expectedKeys.has(key)) {
-        delete process.env[key];
-      } else if (env[key] !== process.env[key]) {
-        process.env[key] = env[key];
-      }
-    }
-    for (const key of Object.keys(env)) {
-      if (!gotKeys.has(key)) {
-        process.env[key] = env[key];
-      }
-    }
+    await new Promise<void>((resolve, reject) => {
+      forkedChild.on('exit', (code) => {
+        if (code === 0) return resolve();
+        console.error(Buffer.concat(outputBuffers).toString());
+        reject(new Error(`node-gyp failed to rebuild '${this.modulePath}'`))
+      });
+    });
   }
 }

--- a/src/module-type/node-gyp/node-gyp.ts
+++ b/src/module-type/node-gyp/node-gyp.ts
@@ -115,7 +115,7 @@ export class NodeGyp extends NativeModule {
       moduleName: this.moduleName,
       nodeGypArgs,
       extraNodeGypArgs,
-      devDir: ELECTRON_GYP_DIR,
+      devDir: this.rebuilder.mode === 'sequential' ? ELECTRON_GYP_DIR : path.resolve(ELECTRON_GYP_DIR, '_p', this.moduleName),
     });
 
     await new Promise<void>((resolve, reject) => {

--- a/src/module-type/node-gyp/worker.ts
+++ b/src/module-type/node-gyp/worker.ts
@@ -1,0 +1,34 @@
+import NodeGypRunner from 'node-gyp';
+import { promisify } from 'util';
+
+process.on('message', async ({
+  nodeGypArgs,
+  devDir,
+  extraNodeGypArgs,
+}) => {
+  const nodeGyp = NodeGypRunner();
+  nodeGyp.parseArgv(nodeGypArgs);
+  nodeGyp.devDir = devDir;
+  let command = nodeGyp.todo.shift();
+  try {
+    while (command) {
+      if (command.name === 'configure') {
+        command.args = command.args.filter((arg: string) => !extraNodeGypArgs.includes(arg));
+      } else if (command.name === 'build' && process.platform === 'win32') {
+        // This is disgusting but it prevents node-gyp from destroying our MSBuild arguments
+        command.args.map = (fn: (arg: string) => string) => {
+          return Array.prototype.map.call(command.args, (arg: string) => {
+            if (arg.startsWith('/p:')) return arg;
+            return fn(arg);
+          });
+        }
+      }
+      await promisify(nodeGyp.commands[command.name])(command.args);
+      command = nodeGyp.todo.shift();
+    }
+    process.exit(0);
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+});

--- a/src/module-type/prebuild-install.ts
+++ b/src/module-type/prebuild-install.ts
@@ -18,13 +18,10 @@ export class PrebuildInstall extends NativeModule {
   }
 
   async run(prebuildInstallPath: string): Promise<void> {
-    const shimExt = process.env.ELECTRON_REBUILD_TESTS ? 'ts' : 'js';
-    const executable = process.env.ELECTRON_REBUILD_TESTS ? path.resolve(__dirname, '..', '..', 'node_modules', '.bin', 'ts-node') : process.execPath;
-
     await spawn(
-      executable,
+      process.execPath,
       [
-        path.resolve(__dirname, '..', `prebuild-shim.${shimExt}`),
+        path.resolve(__dirname, '..', `prebuild-shim.js`),
         prebuildInstallPath,
         `--arch=${this.rebuilder.arch}`,
         `--platform=${this.rebuilder.platform}`,

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -36,7 +36,7 @@ export interface RebuilderOptions extends RebuildOptions {
 
 const d = debug('electron-rebuild');
 
-const defaultMode: RebuildMode = 'parallel';
+const defaultMode: RebuildMode = 'sequential';
 const defaultTypes: ModuleType[] = ['prod', 'optional'];
 
 export class Rebuilder implements IRebuilder {

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -36,7 +36,7 @@ export interface RebuilderOptions extends RebuildOptions {
 
 const d = debug('electron-rebuild');
 
-const defaultMode: RebuildMode = 'sequential';
+const defaultMode: RebuildMode = 'parallel';
 const defaultTypes: ModuleType[] = ['prod', 'optional'];
 
 export class Rebuilder implements IRebuilder {

--- a/test/arch.ts
+++ b/test/arch.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { getNodeArch, uname } from '../src/arch';
+import { getNodeArch, uname } from '../lib/arch';
 
 // Copied from @electron/get
 describe('uname()', () => {

--- a/test/electron-locator.ts
+++ b/test/electron-locator.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 
-import { locateElectronModule } from '../src/electron-locator';
+import { locateElectronModule } from '../lib/electron-locator';
 
 const baseFixtureDir = path.resolve(__dirname, 'fixture', 'electron-locator')
 

--- a/test/fixture/native-app1/package.json
+++ b/test/fixture/native-app1/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.0.10",
-    "ffi-napi": "2.4.5"
+    "ffi-napi": "4.0.3"
   },
   "dependencies": {
     "@newrelic/native-metrics": "5.3.0",

--- a/test/module-type-node-gyp.ts
+++ b/test/module-type-node-gyp.ts
@@ -4,7 +4,7 @@ import os from 'os';
 import path from 'path';
 
 import { cleanupTestModule, resetTestModule } from './helpers/module-setup';
-import { NodeGyp } from '../src/module-type/node-gyp';
+import { NodeGyp } from '../src/module-type/node-gyp/node-gyp';
 import { Rebuilder } from '../src/rebuild';
 
 describe('node-gyp', () => {

--- a/test/module-type-node-gyp.ts
+++ b/test/module-type-node-gyp.ts
@@ -4,8 +4,8 @@ import os from 'os';
 import path from 'path';
 
 import { cleanupTestModule, resetTestModule } from './helpers/module-setup';
-import { NodeGyp } from '../src/module-type/node-gyp/node-gyp';
-import { Rebuilder } from '../src/rebuild';
+import { NodeGyp } from '../lib/module-type/node-gyp/node-gyp';
+import { Rebuilder } from '../lib/rebuild';
 
 describe('node-gyp', () => {
   describe('buildArgs', () => {

--- a/test/module-type-prebuild-install.ts
+++ b/test/module-type-prebuild-install.ts
@@ -21,10 +21,6 @@ describe('prebuild-install', () => {
     lifecycle: new EventEmitter()
   };
 
-  before(() => {
-    process.env.ELECTRON_REBUILD_TESTS = 'true';
-  });
-
   describe('Node-API support', function() {
     this.timeout(TIMEOUT_IN_MILLISECONDS);
 
@@ -56,9 +52,5 @@ describe('prebuild-install', () => {
       const prebuildInstall = new PrebuildInstall(rebuilder, modulePath);
       expect(prebuildInstall.findPrebuiltModule()).to.eventually.be.rejectedWith("Native module 'farmhash' requires Node-API but Electron v2.0.0 does not support Node-API");
     });
-  });
-
-  after(() => {
-    delete process.env.ELECTRON_REBUILD_TESTS;
   });
 });

--- a/test/module-type-prebuild-install.ts
+++ b/test/module-type-prebuild-install.ts
@@ -5,8 +5,8 @@ import os from 'os';
 import path from 'path';
 
 import { cleanupTestModule, resetTestModule, TIMEOUT_IN_MILLISECONDS } from './helpers/module-setup';
-import { PrebuildInstall } from '../src/module-type/prebuild-install';
-import { Rebuilder } from '../src/rebuild';
+import { PrebuildInstall } from '../lib/module-type/prebuild-install';
+import { Rebuilder } from '../lib/rebuild';
 
 chai.use(chaiAsPromised);
 

--- a/test/module-type-prebuildify.ts
+++ b/test/module-type-prebuildify.ts
@@ -6,8 +6,8 @@ import {
   determineNativePrebuildArch,
   determineNativePrebuildExtension,
   Prebuildify
-} from '../src/module-type/prebuildify';
-import { Rebuilder, RebuilderOptions } from '../src/rebuild';
+} from '../lib/module-type/prebuildify';
+import { Rebuilder, RebuilderOptions } from '../lib/rebuild';
 
 describe('determineNativePrebuildArch', () => {
   it('returns arm if passed in armv7l', () => {

--- a/test/read-package-json.ts
+++ b/test/read-package-json.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { expect } from 'chai';
 
-import { readPackageJson } from '../src/read-package-json';
+import { readPackageJson } from '../lib/read-package-json';
 
 describe('read-package-json', () => {
   it('should find a package.json file from the given directory', async () => {

--- a/test/rebuild-yarnworkspace.ts
+++ b/test/rebuild-yarnworkspace.ts
@@ -5,8 +5,8 @@ import { spawn } from '@malept/cross-spawn-promise';
 
 import { expectNativeModuleToBeRebuilt, expectNativeModuleToNotBeRebuilt } from './helpers/rebuild';
 import { getExactElectronVersionSync } from './helpers/electron-version';
-import { getProjectRootPath } from '../src/search-module';
-import { rebuild } from '../src/rebuild';
+import { getProjectRootPath } from '../lib/search-module';
+import { rebuild } from '../lib/rebuild';
 
 const testElectronVersion = getExactElectronVersionSync();
 

--- a/test/rebuild.ts
+++ b/test/rebuild.ts
@@ -6,7 +6,7 @@ import * as os from 'os';
 import { cleanupTestModule, MINUTES_IN_MILLISECONDS, resetMSVSVersion, resetTestModule, TIMEOUT_IN_MILLISECONDS } from './helpers/module-setup';
 import { expectNativeModuleToBeRebuilt, expectNativeModuleToNotBeRebuilt } from './helpers/rebuild';
 import { getExactElectronVersionSync } from './helpers/electron-version';
-import { rebuild } from '../src/rebuild';
+import { rebuild } from '../lib/rebuild';
 
 const testElectronVersion = getExactElectronVersionSync();
 
@@ -19,7 +19,6 @@ describe('rebuilder', () => {
     before(async () => {
       await resetTestModule(testModulePath);
 
-      process.env.ELECTRON_REBUILD_TESTS = 'true';
       await rebuild({
         buildPath: testModulePath,
         electronVersion: testElectronVersion,
@@ -59,7 +58,6 @@ describe('rebuilder', () => {
     });
 
     after(async () => {
-      delete process.env.ELECTRON_REBUILD_TESTS;
       await cleanupTestModule(testModulePath);
     });
   });

--- a/test/search-module.ts
+++ b/test/search-module.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
 
-import { getProjectRootPath } from '../src/search-module';
+import { getProjectRootPath } from '../lib/search-module';
 
 let baseDir: string;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
   },
   "exclude": [
     "node_modules",
-    "lib"
+    "lib",
+    "test"
   ]
 }


### PR DESCRIPTION
This refactors the node-gyp logic to run inside a forked child worker so that we can effectively run multiple at the same time without issues.

This also cleans up some stuff around how we build / test to make this easier too.

This PR doesn't change the default but it makes our tests ~33% faster when running locally with `parallel` mode instead of `sequential`

Example of this change + parallel vs current `main`

| Before | After |
| -------|-------|
| <img width="286" alt="image" src="https://user-images.githubusercontent.com/6634592/231422930-05ba5416-53e4-4c00-9dc7-3b9515d653ec.png"> | <img width="281" alt="image" src="https://user-images.githubusercontent.com/6634592/231423060-2821c094-37a3-4006-8928-7b8cb07aaeee.png"> |

You'll only get this perf boost if you manually enable parallel mode but that's super easy to do and now it actually Works ™️ 