### PR TITLE
fix: platform parameter

### DIFF
--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -48,7 +48,7 @@ export class Rebuilder implements IRebuilder {
   public lifecycle: EventEmitter;
   public buildPath: string;
   public electronVersion: string;
-  public platform: string = process.platform;
+  public platform: string;
   public arch: string;
   public force: boolean;
   public headerURL: string;
@@ -65,6 +65,7 @@ export class Rebuilder implements IRebuilder {
     this.lifecycle = options.lifecycle;
     this.buildPath = options.buildPath;
     this.electronVersion = options.electronVersion;
+    this.platform = options.platform || process.platform;
     this.arch = options.arch || process.arch;
     this.force = options.force || false;
     this.headerURL = options.headerURL || 'https://www.electronjs.org/headers';


### PR DESCRIPTION
The fix is needed for controlling the OS during the assembly process. For example, there is currently an issue when using electron-builder version 24, which started using electron/rebuild. The problem can be found here: [link to the specific line of code on GitHub](https://github.com/electron-userland/electron-builder/blob/46524169cefbfa18e342d7fa19e79e710aae848e/packages/app-builder-lib/src/util/yarn.ts#L162).

The OS will always be the current one, and because of this, it is not possible to download the necessary bindings.