### PR TITLE
build: drop unused .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-test-dist/
-lib/test


### PR DESCRIPTION
This package already has a `"files"` field in `package.json` so it wasn't making use of `.npmignore` anyway.

https://github.com/electron/rebuild/blob/37babeed7ded93ca2dfedc77b8e2d5ee01479d70/package.json#L22-L24