### PR TITLE
fix: use 'target_arch' for node-pre-gyp

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "node-api-version": "^0.1.4",
     "node-gyp": "^9.0.0",
     "ora": "^5.1.0",
-    "read-binary-file-arch": "^1.0.5",
+    "read-binary-file-arch": "^1.0.6",
     "semver": "^7.3.5",
     "tar": "^6.0.5",
     "yargs": "^17.0.1"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "node-api-version": "^0.1.4",
     "node-gyp": "^9.0.0",
     "ora": "^5.1.0",
+    "read-binary-file-arch": "^1.0.3",
     "semver": "^7.3.5",
     "tar": "^6.0.5",
     "yargs": "^17.0.1"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "node-api-version": "^0.1.4",
     "node-gyp": "^9.0.0",
     "ora": "^5.1.0",
-    "read-binary-file-arch": "^1.0.3",
+    "read-binary-file-arch": "^1.0.5",
     "semver": "^7.3.5",
     "tar": "^6.0.5",
     "yargs": "^17.0.1"

--- a/src/module-type/node-pre-gyp.ts
+++ b/src/module-type/node-pre-gyp.ts
@@ -22,6 +22,7 @@ export class NodePreGyp extends NativeModule {
         nodePreGypPath,
         'reinstall',
         '--fallback-to-build',
+        '--update-binary', // always overwrite existing binary
         `--arch=${this.rebuilder.arch}`, // fallback build arch
         `--target_arch=${this.rebuilder.arch}`, // prebuild arch
         `--target_platform=${this.rebuilder.platform}`,

--- a/src/module-type/node-pre-gyp.ts
+++ b/src/module-type/node-pre-gyp.ts
@@ -22,8 +22,8 @@ export class NodePreGyp extends NativeModule {
         nodePreGypPath,
         'reinstall',
         '--fallback-to-build',
-        `--arch=${this.rebuilder.arch}`,
-        `--platform=${this.rebuilder.platform}`,
+        `--target_arch=${this.rebuilder.arch}`,
+        `--target_platform=${this.rebuilder.platform}`,
         ...await this.getNodePreGypRuntimeArgs(),
       ],
       {

--- a/src/module-type/node-pre-gyp.ts
+++ b/src/module-type/node-pre-gyp.ts
@@ -1,5 +1,6 @@
 import debug from 'debug';
 import { spawn } from '@malept/cross-spawn-promise';
+import { readBinaryFileArch } from 'read-binary-file-arch';
 
 import { locateBinary, NativeModule } from '.';
 const d = debug('electron-rebuild');
@@ -16,13 +17,15 @@ export class NodePreGyp extends NativeModule {
   }
 
   async run(nodePreGypPath: string): Promise<void> {
+    const redownloadBinary = await this.shouldUpdateBinary(nodePreGypPath);
+
     await spawn(
       process.execPath,
       [
         nodePreGypPath,
         'reinstall',
         '--fallback-to-build',
-        '--update-binary', // always overwrite existing binary
+        ...(redownloadBinary ? ['--update-binary'] : []),
         `--arch=${this.rebuilder.arch}`, // fallback build arch
         `--target_arch=${this.rebuilder.arch}`, // prebuild arch
         `--target_platform=${this.rebuilder.platform}`,
@@ -66,5 +69,54 @@ export class NodePreGyp extends NativeModule {
         `--dist-url=${this.rebuilder.headerURL}`,
       ];
     }
+  }
+
+  private async shouldUpdateBinary(nodePreGypPath: string) {
+    let shouldUpdate = false;
+
+    // Redownload binary only if the existing module arch differs from the
+    // target arch.
+    try {
+      const modulePaths = await this.getModulePaths(nodePreGypPath);
+      d('module paths:', modulePaths);
+      for (const modulePath of modulePaths) {
+        let moduleArch;
+        try {
+          moduleArch = await readBinaryFileArch(modulePath);
+          d('module arch:', moduleArch);
+        } catch (error) {
+          d('failed to read module arch:', error.message);
+          continue;
+        }
+
+        if (moduleArch && moduleArch !== this.rebuilder.arch) {
+          shouldUpdate = true;
+          d('module architecture differs:', `${moduleArch} !== ${this.rebuilder.arch}`);
+          break;
+        }
+      }
+    } catch (error) {
+      d('failed to get existing binary arch:', error.message);
+
+      // Assume architecture differs
+      shouldUpdate = true;
+    }
+
+    return shouldUpdate;
+  }
+
+  private async getModulePaths(nodePreGypPath: string): Promise<string[]> {
+    const results = await spawn(process.execPath, [
+      nodePreGypPath,
+      'reveal',
+      'module', // pick property with module path
+      `--target_arch=${this.rebuilder.arch}`,
+      `--target_platform=${this.rebuilder.platform}`,
+    ], {
+      cwd: this.modulePath,
+    });
+
+    // Packages with multiple binaries will output one per line
+    return results.split('\n').filter(Boolean);
   }
 }

--- a/src/module-type/node-pre-gyp.ts
+++ b/src/module-type/node-pre-gyp.ts
@@ -22,7 +22,8 @@ export class NodePreGyp extends NativeModule {
         nodePreGypPath,
         'reinstall',
         '--fallback-to-build',
-        `--target_arch=${this.rebuilder.arch}`,
+        `--arch=${this.rebuilder.arch}`, // fallback build arch
+        `--target_arch=${this.rebuilder.arch}`, // prebuild arch
         `--target_platform=${this.rebuilder.platform}`,
         ...await this.getNodePreGypRuntimeArgs(),
       ],

--- a/test/module-type-node-pre-gyp.ts
+++ b/test/module-type-node-pre-gyp.ts
@@ -53,8 +53,14 @@ describe('node-pre-gyp', function () {
     let nodePreGyp = new NodePreGyp(rebuilder, modulePath);
     expect(await nodePreGyp.findPrebuiltModule()).to.equal(true);
 
-    const arch = rebuilderArgs.arch === 'arm64' ? 'x64' : 'arm64';
-    rebuilder = new Rebuilder({ ...rebuilderArgs, arch });
+    let alternativeArch: string;
+    if (process.platform === 'win32') {
+      alternativeArch = rebuilderArgs.arch === 'x64' ? 'ia32' : 'x64';
+    } else {
+      alternativeArch = rebuilderArgs.arch === 'arm64' ? 'x64' : 'arm64'
+    }
+
+    rebuilder = new Rebuilder({ ...rebuilderArgs, arch: alternativeArch });
     nodePreGyp = new NodePreGyp(rebuilder, modulePath);
     expect(await nodePreGyp.findPrebuiltModule()).to.equal(true);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1200,6 +1200,13 @@ debug@4, debug@4.3.3, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
   dependencies:
     ms "2.1.2"
 
+debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
 decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -2772,6 +2779,13 @@ randombytes@^2.1.0:
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
   dependencies:
     safe-buffer "^5.1.0"
+
+read-binary-file-arch@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/read-binary-file-arch/-/read-binary-file-arch-1.0.3.tgz#f280609075b1aa765509b82f9684648a8ac0bf69"
+  integrity sha512-ig7VB4jeXFhqddLu2D9JjrCHLF1s34+PjgyRMzgtnTlxmnY3WGH+A5B+cNJzzF7MUu6xTh7BPCwv1Q9c3ibAsA==
+  dependencies:
+    debug "^4.3.4"
 
 readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2780,10 +2780,10 @@ randombytes@^2.1.0:
   dependencies:
     safe-buffer "^5.1.0"
 
-read-binary-file-arch@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/read-binary-file-arch/-/read-binary-file-arch-1.0.5.tgz#9fc347a1017a4894021eea1e6d375422f6be2077"
-  integrity sha512-Tcz+mwwDBsZ7H6e3tq/8knMhhwHOXcRxm+CSw43b6vyDiyb9My1pzdV1qSf+NmDyp0xXkHyRmmNHeH2MNd3tZQ==
+read-binary-file-arch@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz#959c4637daa932280a9b911b1a6766a7e44288fc"
+  integrity sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==
   dependencies:
     debug "^4.3.4"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2780,10 +2780,10 @@ randombytes@^2.1.0:
   dependencies:
     safe-buffer "^5.1.0"
 
-read-binary-file-arch@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/read-binary-file-arch/-/read-binary-file-arch-1.0.3.tgz#f280609075b1aa765509b82f9684648a8ac0bf69"
-  integrity sha512-ig7VB4jeXFhqddLu2D9JjrCHLF1s34+PjgyRMzgtnTlxmnY3WGH+A5B+cNJzzF7MUu6xTh7BPCwv1Q9c3ibAsA==
+read-binary-file-arch@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/read-binary-file-arch/-/read-binary-file-arch-1.0.5.tgz#9fc347a1017a4894021eea1e6d375422f6be2077"
+  integrity sha512-Tcz+mwwDBsZ7H6e3tq/8knMhhwHOXcRxm+CSw43b6vyDiyb9My1pzdV1qSf+NmDyp0xXkHyRmmNHeH2MNd3tZQ==
   dependencies:
     debug "^4.3.4"
 


### PR DESCRIPTION
The arguments provided to node-pre-gyp are incomplete, resulting in prebuilt binaries not downloading the correct architecture. [From the readme](https://github.com/mapbox/node-pre-gyp#options), `--target_arch` and `--target_platform` are both used for downloading the prebuilt binaries. The `--arch` option seems to only be used when falling back to the `node-gyp` local build.

Also, if the binary already exists, `--update-binary` is required to redownload in the case of changing the targeted architecture. 

Follow up to https://github.com/electron/rebuild/pull/1095