### PR TITLE
feat: Upgrade `node-api-version` to add support for NodeAPI level 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "fs-extra": "^10.0.0",
     "got": "^11.7.0",
     "node-abi": "^3.45.0",
-    "node-api-version": "^0.1.4",
+    "node-api-version": "^0.2.0",
     "node-gyp": "^9.0.0",
     "ora": "^5.1.0",
     "semver": "^7.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2444,10 +2444,10 @@ node-abi@^3.45.0:
   dependencies:
     semver "^7.3.5"
 
-node-api-version@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/node-api-version/-/node-api-version-0.1.4.tgz#1ed46a485e462d55d66b5aa1fe2821720dedf080"
-  integrity sha512-KGXihXdUChwJAOHO53bv9/vXcLmdUsZ6jIptbvYvkpKfth+r7jw44JkVxQFA3kX5nQjzjmGu1uAu/xNNLNlI5g==
+node-api-version@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/node-api-version/-/node-api-version-0.2.0.tgz#5177441da2b1046a4d4547ab9e0972eed7b1ac1d"
+  integrity sha512-fthTTsi8CxaBXMaBAD7ST2uylwvsnYxh2PfaScwpMhos6KlSFajXQPcM4ogNE1q2s3Lbz9GCGqeIHC+C6OZnKg==
   dependencies:
     semver "^7.3.5"
 


### PR DESCRIPTION
I [recently updated](https://github.com/timfish/node-api-version/commit/6333f20b31f0ff4c1651f3c94da45fbed0ab33cd#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346) `node-api-version` to add support for API level 9. 

I should have just published this change as a patch release!