### PR TITLE
build: fix repository.url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/electron/rebuild"
+    "url": "git+https://github.com/electron/rebuild.git"
   },
   "keywords": [
     "electron"


### PR DESCRIPTION
Clears this warning during publish:

```
npm WARN publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm WARN publish errors corrected:
npm WARN publish "repository.url" was normalized to "git+https://github.com/electron/rebuild.git"
```