### PR TITLE
fix: cross-platform prebuild downloads

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -22,6 +22,7 @@ type HashTree = { [path: string]: string | HashTree };
 type CacheOptions = {
   ABI: string;
   arch: string;
+  platform: string;
   debug: boolean;
   electronVersion: string;
   headerURL: string;
@@ -159,6 +160,7 @@ export async function generateCacheKey(opts: CacheOptions): Promise<string> {
     .update(path.basename(opts.modulePath))
     .update(opts.ABI)
     .update(opts.arch)
+    .update(opts.platform)
     .update(opts.debug ? 'debug' : 'not debug')
     .update(opts.headerURL)
     .update(opts.electronVersion);

--- a/src/module-rebuilder.ts
+++ b/src/module-rebuilder.ts
@@ -151,10 +151,6 @@ export class ModuleRebuilder {
       return true;
     }
 
-    if (this.rebuilder.platform !== process.platform) {
-      throw new Error("OS Limitation - It is not possible to cross-compile native modules from source")
-    }
-
     return await this.rebuildNodeGypModule(cacheKey);
   }
 }

--- a/src/module-rebuilder.ts
+++ b/src/module-rebuilder.ts
@@ -151,6 +151,10 @@ export class ModuleRebuilder {
       return true;
     }
 
+    if (this.rebuilder.platform !== process.platform) {
+      throw new Error("OS Limitation - It is not possible to cross-compile native modules from source")
+    }
+
     return await this.rebuildNodeGypModule(cacheKey);
   }
 }

--- a/src/module-type/node-gyp/node-gyp.ts
+++ b/src/module-type/node-gyp/node-gyp.ts
@@ -84,6 +84,10 @@ export class NodeGyp extends NativeModule {
   }
 
   async rebuildModule(): Promise<void> {
+    if (this.rebuilder.platform !== process.platform) {
+      throw new Error("node-gyp does not support cross-compiling native modules from source")
+    }
+
     if (this.modulePath.includes(' ')) {
       console.error('Attempting to build a module with a space in the path');
       console.error('See https://github.com/nodejs/node-gyp/issues/65#issuecomment-368820565 for reasons why this may not work');

--- a/src/module-type/node-gyp/node-gyp.ts
+++ b/src/module-type/node-gyp/node-gyp.ts
@@ -85,7 +85,7 @@ export class NodeGyp extends NativeModule {
 
   async rebuildModule(): Promise<void> {
     if (this.rebuilder.platform !== process.platform) {
-      throw new Error("node-gyp does not support cross-compiling native modules from source")
+      throw new Error("node-gyp does not support cross-compiling native modules from source.");
     }
 
     if (this.modulePath.includes(' ')) {

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -20,6 +20,13 @@ export interface RebuildOptions {
    */
   electronVersion: string;
   /**
+   * Override the target platform to something other than the host system platform.
+   * Note: This only applies to downloading prebuilt binaries. **It is not possible to cross-compile native modules**
+   * 
+   * @defaultValue The system {@link https://nodejs.org/api/process.html#processplatform | `process.arch`} value
+   */
+  platform?: string;
+  /**
    * Override the target rebuild architecture to something other than the host system architecture.
    * 
    * @defaultValue The system {@link https://nodejs.org/api/process.html#processarch | `process.arch`} value
@@ -132,7 +139,7 @@ export class Rebuilder implements IRebuilder {
   public lifecycle: EventEmitter;
   public buildPath: string;
   public electronVersion: string;
-  public platform: string = process.platform;
+  public platform: string
   public arch: string;
   public force: boolean;
   public headerURL: string;
@@ -151,6 +158,7 @@ export class Rebuilder implements IRebuilder {
     this.lifecycle = options.lifecycle;
     this.buildPath = options.buildPath;
     this.electronVersion = options.electronVersion;
+    this.platform = options.platform || process.platform
     this.arch = options.arch || process.arch;
     this.force = options.force || false;
     this.headerURL = options.headerURL || 'https://www.electronjs.org/headers';

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -21,7 +21,7 @@ export interface RebuildOptions {
   electronVersion: string;
   /**
    * Override the target platform to something other than the host system platform.
-   * Note: This only applies to downloading prebuilt binaries. **It is not possible to cross-compile native modules**
+   * Note: This only applies to downloading prebuilt binaries. **It is not possible to cross-compile native modules.**
    * 
    * @defaultValue The system {@link https://nodejs.org/api/process.html#processplatform | `process.arch`} value
    */

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -158,7 +158,7 @@ export class Rebuilder implements IRebuilder {
     this.lifecycle = options.lifecycle;
     this.buildPath = options.buildPath;
     this.electronVersion = options.electronVersion;
-    this.platform = options.platform || process.platform
+    this.platform = options.platform || process.platform;
     this.arch = options.arch || process.arch;
     this.force = options.force || false;
     this.headerURL = options.headerURL || 'https://www.electronjs.org/headers';

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -139,7 +139,7 @@ export class Rebuilder implements IRebuilder {
   public lifecycle: EventEmitter;
   public buildPath: string;
   public electronVersion: string;
-  public platform: NodeJS.Platform
+  public platform: NodeJS.Platform;
   public arch: string;
   public force: boolean;
   public headerURL: string;

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -23,9 +23,9 @@ export interface RebuildOptions {
    * Override the target platform to something other than the host system platform.
    * Note: This only applies to downloading prebuilt binaries. **It is not possible to cross-compile native modules.**
    * 
-   * @defaultValue The system {@link https://nodejs.org/api/process.html#processplatform | `process.arch`} value
+   * @defaultValue The system {@link https://nodejs.org/api/process.html#processplatform | `process.platform`} value
    */
-  platform?: string;
+  platform?: NodeJS.Platform;
   /**
    * Override the target rebuild architecture to something other than the host system architecture.
    * 
@@ -139,7 +139,7 @@ export class Rebuilder implements IRebuilder {
   public lifecycle: EventEmitter;
   public buildPath: string;
   public electronVersion: string;
-  public platform: string
+  public platform: NodeJS.Platform
   public arch: string;
   public force: boolean;
   public headerURL: string;
@@ -207,6 +207,7 @@ export class Rebuilder implements IRebuilder {
       'rebuilding with args:',
       this.buildPath,
       this.electronVersion,
+      this.platform,
       this.arch,
       extraModules,
       this.force,
@@ -297,6 +298,7 @@ export class Rebuilder implements IRebuilder {
       cacheKey = await generateCacheKey({
         ABI: this.ABI,
         arch: this.arch,
+        platform: this.platform,
         debug: this.debug,
         electronVersion: this.electronVersion,
         headerURL: this.headerURL,

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export interface IRebuilder {
   lifecycle: EventEmitter;
   mode: RebuildMode;
   msvsVersion?: string;
-  platform: string;
+  platform: NodeJS.Platform;
   prebuildTagPrefix: string;
   buildFromSource: boolean;
   useCache: boolean;

--- a/test/module-type-node-gyp.ts
+++ b/test/module-type-node-gyp.ts
@@ -54,5 +54,25 @@ describe('node-gyp', () => {
         expect(args).to.not.include('--force-process-config');
       });
     });
+
+    context('cross-compilation', async () => {
+      it('throws error early', async () => {
+        const platform: NodeJS.Platform = 'win32'
+        const rebuilder = new Rebuilder({
+          buildPath: testModulePath,
+          electronVersion: '15.3.0',
+          lifecycle: new EventEmitter(),
+          platform,
+          buildFromSource: true // to force node-gyp to execute
+        });
+        const nodeGyp = new NodeGyp(rebuilder, testModulePath);
+        const executor = () => nodeGyp.rebuildModule();
+        if (process.platform === platform) {
+          expect(executor).does.not.throw()
+        } else {
+          expect(executor).throws()
+        }
+      })
+    })
   });
 });

--- a/test/module-type-node-gyp.ts
+++ b/test/module-type-node-gyp.ts
@@ -1,9 +1,12 @@
 import { EventEmitter } from 'events';
-import { expect } from 'chai';
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import { cleanupTestModule, resetTestModule, TEST_MODULE_PATH as testModulePath } from './helpers/module-setup';
 import { NodeGyp } from '../lib/module-type/node-gyp/node-gyp';
 import { Rebuilder } from '../lib/rebuild';
+
+chai.use(chaiAsPromised);
 
 describe('node-gyp', () => {
   describe('buildArgs', () => {
@@ -73,13 +76,7 @@ describe('node-gyp', () => {
         const nodeGyp = new NodeGyp(rebuilder, testModulePath);
         
         const errorMessage = "node-gyp does not support cross-compiling native modules from source.";
-        let errorThrown = false;
-        await nodeGyp.rebuildModule().catch((err) => {
-          if (err.message === errorMessage) {
-            errorThrown = true
-          }
-        });
-        expect(errorThrown).to.be.true;
+        expect(nodeGyp.rebuildModule()).to.eventually.be.rejectedWith(new Error(errorMessage))
       })
     })
   });

--- a/test/module-type-node-gyp.ts
+++ b/test/module-type-node-gyp.ts
@@ -56,21 +56,29 @@ describe('node-gyp', () => {
     });
 
     context('cross-compilation', async () => {
-      it('throws error early', async () => {
+      it('throws error early if platform mismatch', async () => {
         const platform: NodeJS.Platform = 'win32'
         const rebuilder = new Rebuilder({
           buildPath: testModulePath,
           electronVersion: '15.3.0',
           lifecycle: new EventEmitter(),
-          platform,
-          buildFromSource: true // to force node-gyp to execute
+          platform
         });
         const nodeGyp = new NodeGyp(rebuilder, testModulePath);
-        const executor = () => nodeGyp.rebuildModule();
+        
+        const errorMessage = "node-gyp does not support cross-compiling native modules from source."
+        let errorThrown = false
+        const executor = () => nodeGyp.rebuildModule().catch((err) => {
+          if (err.message === errorMessage) {
+            errorThrown = true
+          }
+        });
+        await executor()
+
         if (process.platform === platform) {
-          expect(executor).does.not.throw()
+          expect(errorThrown).to.be.false
         } else {
-          expect(executor).throws()
+          expect(errorThrown).to.be.true
         }
       })
     })

--- a/test/module-type-node-gyp.ts
+++ b/test/module-type-node-gyp.ts
@@ -60,11 +60,11 @@ describe('node-gyp', () => {
 
     context('cross-compilation', async () => {
       it('throws error early if platform mismatch', async function () {
-        const platform: NodeJS.Platform = 'win32';
+        let platform: NodeJS.Platform = 'darwin';
 
         // we're verifying platform mismatch error throwing, not `rebuildModule` rebuilding.
         if (process.platform === platform) {
-          this.skip(); 
+          platform = 'win32';
         }
 
         const rebuilder = new Rebuilder({

--- a/test/module-type-node-gyp.ts
+++ b/test/module-type-node-gyp.ts
@@ -56,8 +56,14 @@ describe('node-gyp', () => {
     });
 
     context('cross-compilation', async () => {
-      it('throws error early if platform mismatch', async () => {
-        const platform: NodeJS.Platform = 'win32'
+      it('throws error early if platform mismatch', async function () {
+        const platform: NodeJS.Platform = 'win32';
+
+        // we're verifying platform mismatch error throwing, not `rebuildModule` rebuilding.
+        if (process.platform === platform) {
+          this.skip(); 
+        }
+
         const rebuilder = new Rebuilder({
           buildPath: testModulePath,
           electronVersion: '15.3.0',
@@ -66,20 +72,14 @@ describe('node-gyp', () => {
         });
         const nodeGyp = new NodeGyp(rebuilder, testModulePath);
         
-        const errorMessage = "node-gyp does not support cross-compiling native modules from source."
-        let errorThrown = false
-        const executor = () => nodeGyp.rebuildModule().catch((err) => {
+        const errorMessage = "node-gyp does not support cross-compiling native modules from source.";
+        let errorThrown = false;
+        await nodeGyp.rebuildModule().catch((err) => {
           if (err.message === errorMessage) {
             errorThrown = true
           }
         });
-        await executor()
-
-        if (process.platform === platform) {
-          expect(errorThrown).to.be.false
-        } else {
-          expect(errorThrown).to.be.true
-        }
+        expect(errorThrown).to.be.true;
       })
     })
   });

--- a/test/module-type-node-pre-gyp.ts
+++ b/test/module-type-node-pre-gyp.ts
@@ -74,7 +74,7 @@ describe('node-pre-gyp', function () {
     if (process.platform === 'win32') {
       alternativePlatform = 'darwin';
     } else {
-      alternativePlatform = 'win32'
+      alternativePlatform = 'win32';
     }
 
     rebuilder = new Rebuilder({ ...rebuilderArgs, platform: alternativePlatform });

--- a/test/module-type-node-pre-gyp.ts
+++ b/test/module-type-node-pre-gyp.ts
@@ -5,7 +5,7 @@ import path from 'path';
 
 import { cleanupTestModule, resetTestModule, TIMEOUT_IN_MILLISECONDS, TEST_MODULE_PATH as testModulePath } from './helpers/module-setup';
 import { NodePreGyp } from '../lib/module-type/node-pre-gyp';
-import { Rebuilder } from '../lib/rebuild';
+import { Rebuilder, RebuilderOptions } from '../lib/rebuild';
 
 chai.use(chaiAsPromised);
 
@@ -13,7 +13,7 @@ describe('node-pre-gyp', function () {
   this.timeout(TIMEOUT_IN_MILLISECONDS);
 
   const modulePath = path.join(testModulePath, 'node_modules', 'sqlite3');
-  const rebuilderArgs = {
+  const rebuilderArgs: RebuilderOptions = {
     buildPath: testModulePath,
     electronVersion: '8.0.0',
     arch: process.arch,
@@ -61,6 +61,23 @@ describe('node-pre-gyp', function () {
     }
 
     rebuilder = new Rebuilder({ ...rebuilderArgs, arch: alternativeArch });
+    nodePreGyp = new NodePreGyp(rebuilder, modulePath);
+    expect(await nodePreGyp.findPrebuiltModule()).to.equal(true);
+  });
+
+  it('should download for target platform', async () => {
+    let rebuilder = new Rebuilder(rebuilderArgs);
+    let nodePreGyp = new NodePreGyp(rebuilder, modulePath);
+    expect(await nodePreGyp.findPrebuiltModule()).to.equal(true);
+
+    let alternativePlatform: NodeJS.Platform;
+    if (process.platform === 'win32') {
+      alternativePlatform = 'darwin';
+    } else {
+      alternativePlatform = 'win32'
+    }
+
+    rebuilder = new Rebuilder({ ...rebuilderArgs, platform: alternativePlatform });
     nodePreGyp = new NodePreGyp(rebuilder, modulePath);
     expect(await nodePreGyp.findPrebuiltModule()).to.equal(true);
   });

--- a/test/module-type-prebuild-install.ts
+++ b/test/module-type-prebuild-install.ts
@@ -65,7 +65,7 @@ describe('prebuild-install', () => {
       if (process.platform === 'win32') {
         alternativePlatform = 'darwin';
       } else {
-        alternativePlatform = 'win32'
+        alternativePlatform = 'win32';
       }
   
       rebuilder = new Rebuilder({ ...rebuilderArgs, platform: alternativePlatform });

--- a/test/module-type-prebuildify.ts
+++ b/test/module-type-prebuildify.ts
@@ -113,4 +113,24 @@ describe('prebuildify', () => {
       });
     });
   });
+  
+  describe('cross-platform downloads', async () => {
+    it('should download for target platform', async () => {
+      const fixtureDir = path.join(fixtureBaseDir, 'napi');
+      let rebuilder = createRebuilder();
+      let prebuildify = new Prebuildify(rebuilder, fixtureDir);
+      expect(await prebuildify.findPrebuiltModule()).to.equal(true);
+  
+      let alternativePlatform: NodeJS.Platform;
+      if (process.platform === 'win32') {
+        alternativePlatform = 'darwin';
+      } else {
+        alternativePlatform = 'win32'
+      }
+  
+      rebuilder = createRebuilder({ platform: alternativePlatform });
+      prebuildify = new Prebuildify(rebuilder, fixtureDir);
+      expect(await prebuildify.findPrebuiltModule()).to.equal(true);
+    });
+  })
 });

--- a/test/module-type-prebuildify.ts
+++ b/test/module-type-prebuildify.ts
@@ -125,7 +125,7 @@ describe('prebuildify', () => {
       if (process.platform === 'win32') {
         alternativePlatform = 'darwin';
       } else {
-        alternativePlatform = 'win32'
+        alternativePlatform = 'win32';
       }
   
       rebuilder = createRebuilder({ platform: alternativePlatform });


### PR DESCRIPTION
Allow prebuilt binaries to be downloaded for target platform instead of hardcoded `process.platform`. Throws an error when attempting to cross-compile (`buildFromSource` || no prebuilds found)
Example: https://github.com/electron/rebuild/blob/cb372cdf09d9ca3ac8f1231608e4ebedddabe51c/src/module-type/node-pre-gyp.ts#L31

Origin of issue: https://github.com/electron/rebuild/blob/cb372cdf09d9ca3ac8f1231608e4ebedddabe51c/src/rebuild.ts#L135

Updated interface with new `platform` option and added docs