### PR TITLE
chore: enforce semicolons via eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,10 @@
           "ignoreRestSiblings": true,
           "vars": "all"
         }
-      ]
+      ],
+      "semi": "off",
+      "@typescript-eslint/semi": "error",
+      "no-unexpected-multiline": "error"
     }
   },
   "eslintIgnore": [

--- a/src/arch.ts
+++ b/src/arch.ts
@@ -13,7 +13,7 @@ export function uname(): string {
 
 export type ConfigVariables = {
   arm_version?: string;
-}
+};
 
 /**
  * Generates an architecture name that would be used in an Electron or Node.js

--- a/src/clang-fetcher.ts
+++ b/src/clang-fetcher.ts
@@ -62,7 +62,7 @@ export async function getClangEnvironmentVars(electronVersion: string, targetArc
       CXX: `"${path.resolve(clangDir, 'clang++')}" ${clangArgs.join(' ')}`,
     },
     args: gypArgs,
-  }
+  };
 }
 
 function clangVersionFromRevision(update: string): string | null {
@@ -92,7 +92,7 @@ async function downloadClangVersion(electronVersion: string) {
   const chromiumRevisionMatch = chromiumRevisionExtractor.exec(electronDeps);
   if (!chromiumRevisionMatch) throw new Error('Failed to determine Chromium revision for given Electron version');
   const chromiumRevision = chromiumRevisionMatch[1];
-  d('fetching clang for Chromium:', chromiumRevision)
+  d('fetching clang for Chromium:', chromiumRevision);
 
   const base64ClangUpdate = await fetch(`https://chromium.googlesource.com/chromium/src.git/+/${chromiumRevision}/tools/clang/scripts/update.py?format=TEXT`, 'text');
   const clangUpdate = Buffer.from(base64ClangUpdate, 'base64').toString('utf8');
@@ -107,7 +107,7 @@ async function downloadClangVersion(electronVersion: string) {
   d('deflating clang');
   zlib.deflateSync(contents);
   const tarPath = path.resolve(ELECTRON_GYP_DIR, `${electronVersion}-clang.tar`);
-  if (await fs.pathExists(tarPath)) await fs.remove(tarPath)
+  if (await fs.pathExists(tarPath)) await fs.remove(tarPath);
   await fs.writeFile(tarPath, Buffer.from(contents));
   await fs.mkdirp(clangDirPath);
   d('tar running on clang');

--- a/src/electron-locator.ts
+++ b/src/electron-locator.ts
@@ -15,7 +15,7 @@ async function locateModuleByRequire(): Promise<string | null> {
     }
   }
 
-  return null
+  return null;
 }
 
 export async function locateElectronModule(

--- a/src/module-type/index.ts
+++ b/src/module-type/index.ts
@@ -10,7 +10,7 @@ type PackageJSONValue = string | Record<string, unknown>;
 export class NativeModule {
   protected rebuilder: IRebuilder;
   private _moduleName: string | undefined;
-  protected modulePath: string
+  protected modulePath: string;
   public nodeAPI: NodeAPI;
   private packageJSON: Record<string, PackageJSONValue | undefined>;
 

--- a/src/module-type/node-gyp/node-gyp.ts
+++ b/src/module-type/node-gyp/node-gyp.ts
@@ -49,16 +49,16 @@ export class NodeGyp extends NativeModule {
 
   async buildArgsFromBinaryField(): Promise<string[]> {
     const binary = await this.packageJSONFieldWithDefault('binary', {}) as Record<string, string>;
-    let napiBuildVersion: number | undefined = undefined
+    let napiBuildVersion: number | undefined = undefined;
     if (Array.isArray(binary.napi_versions)) {
-      napiBuildVersion = this.nodeAPI.getNapiVersion(binary.napi_versions.map(str => Number(str)))
+      napiBuildVersion = this.nodeAPI.getNapiVersion(binary.napi_versions.map(str => Number(str)));
     }
     const flags = await Promise.all(Object.entries(binary).map(async ([binaryKey, binaryValue]) => {
       if (binaryKey === 'napi_versions') {
         return;
       }
 
-      let value = binaryValue
+      let value = binaryValue;
 
       if (binaryKey === 'module_path') {
         value = path.resolve(this.modulePath, value);
@@ -71,14 +71,14 @@ export class NodeGyp extends NativeModule {
         .replace('{version}', await this.packageJSONField('version') as string)
         .replace('{libc}', await detectLibc.family() || 'unknown');
       if (napiBuildVersion !== undefined) {
-        value = value.replace('{napi_build_version}', napiBuildVersion.toString())
+        value = value.replace('{napi_build_version}', napiBuildVersion.toString());
       }
       for (const [replaceKey, replaceValue] of Object.entries(binary)) {
         value = value.replace(`{${replaceKey}}`, replaceValue);
       }
 
       return `--${binaryKey}=${value}`;
-    }))
+    }));
 
     return flags.filter(value => value) as string[];
   }
@@ -128,7 +128,7 @@ export class NodeGyp extends NativeModule {
       forkedChild.on('exit', (code) => {
         if (code === 0) return resolve();
         console.error(Buffer.concat(outputBuffers).toString());
-        reject(new Error(`node-gyp failed to rebuild '${this.modulePath}'`))
+        reject(new Error(`node-gyp failed to rebuild '${this.modulePath}'`));
       });
     });
   }

--- a/src/module-type/node-gyp/worker.ts
+++ b/src/module-type/node-gyp/worker.ts
@@ -21,7 +21,7 @@ process.on('message', async ({
             if (arg.startsWith('/p:')) return arg;
             return fn(arg);
           });
-        }
+        };
       }
       await promisify(nodeGyp.commands[command.name])(command.args);
       command = nodeGyp.todo.shift();

--- a/src/module-type/prebuild-install.ts
+++ b/src/module-type/prebuild-install.ts
@@ -10,7 +10,7 @@ export class PrebuildInstall extends NativeModule {
   async usesTool(): Promise<boolean> {
     const dependencies = await this.packageJSONFieldWithDefault('dependencies', {});
     // eslint-disable-next-line no-prototype-builtins
-    return dependencies.hasOwnProperty('prebuild-install')
+    return dependencies.hasOwnProperty('prebuild-install');
   }
 
   async locateBinary(): Promise<string | null> {
@@ -59,7 +59,7 @@ export class PrebuildInstall extends NativeModule {
    * Whether a prebuild-install-based native module exists.
    */
   async prebuiltModuleExists(): Promise<boolean> {
-    return fs.pathExists(path.resolve(this.modulePath, 'prebuilds', `${this.rebuilder.platform}-${this.rebuilder.arch}`, `electron-${this.rebuilder.ABI}.node`))
+    return fs.pathExists(path.resolve(this.modulePath, 'prebuilds', `${this.rebuilder.platform}-${this.rebuilder.arch}`, `electron-${this.rebuilder.ABI}.node`));
   }
 
   async getPrebuildInstallRuntimeArgs(): Promise<string[]> {
@@ -69,12 +69,12 @@ export class PrebuildInstall extends NativeModule {
       return [
         '--runtime=napi',
         `--target=${napiVersion}`,
-      ]
+      ];
     } else {
       return [
         '--runtime=electron',
         `--target=${this.rebuilder.electronVersion}`,
-      ]
+      ];
     }
   }
 }

--- a/src/module-type/prebuildify.ts
+++ b/src/module-type/prebuildify.ts
@@ -44,7 +44,7 @@ export class Prebuildify extends NativeModule {
 
     const prebuildsDir = path.join(this.modulePath, 'prebuilds');
     if (!(await fs.pathExists(prebuildsDir))) {
-      d(`Could not find the prebuilds directory at "${prebuildsDir}"`)
+      d(`Could not find the prebuilds directory at "${prebuildsDir}"`);
       return false;
     }
 

--- a/src/node-api.ts
+++ b/src/node-api.ts
@@ -30,7 +30,7 @@ export class NodeAPI {
     const filteredVersions = moduleNapiVersions.filter((v) => (v <= electronNapiVersion));
 
     if (filteredVersions.length === 0) {
-      throw new Error(`Native module '${this.moduleName}' supports Node-API versions ${moduleNapiVersions} but Electron v${this.electronVersion} only supports Node-API v${electronNapiVersion}`)
+      throw new Error(`Native module '${this.moduleName}' supports Node-API versions ${moduleNapiVersions} but Electron v${this.electronVersion} only supports Node-API v${electronNapiVersion}`);
     }
 
     return Math.max(...filteredVersions);

--- a/src/search-module.ts
+++ b/src/search-module.ts
@@ -76,7 +76,7 @@ export async function searchForNodeModules(cwd: string, rootPath?: string): Prom
 export async function getProjectRootPath(cwd: string): Promise<string> {
   for (const lockFilename of ['yarn.lock', 'package-lock.json', 'pnpm-lock.yaml']) {
     const pathGenerator: PathGeneratorFunction = (traversedPath) => path.join(traversedPath, lockFilename);
-    const lockPaths = await traverseAncestorDirectories(cwd, pathGenerator, undefined, 1)
+    const lockPaths = await traverseAncestorDirectories(cwd, pathGenerator, undefined, 1);
     if (lockPaths.length > 0) {
       return path.dirname(lockPaths[0]);
     }

--- a/src/sysroot-fetcher.ts
+++ b/src/sysroot-fetcher.ts
@@ -12,9 +12,9 @@ const d = debug('electron-rebuild');
 const sysrootArchAliases = {
   x64: 'amd64',
   ia32: 'i386',
-}
+};
 
-const SYSROOT_BASE_URL = 'https://dev-cdn.electronjs.org/linux-sysroots'
+const SYSROOT_BASE_URL = 'https://dev-cdn.electronjs.org/linux-sysroots';
 
 export async function downloadLinuxSysroot(electronVersion: string, targetArch: string): Promise<string> {
   d('fetching sysroot for Electron:', electronVersion);

--- a/test/electron-locator.ts
+++ b/test/electron-locator.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 
 import { locateElectronModule } from '../lib/electron-locator';
 
-const baseFixtureDir = path.resolve(__dirname, 'fixture', 'electron-locator')
+const baseFixtureDir = path.resolve(__dirname, 'fixture', 'electron-locator');
 
 async function expectElectronCanBeFound(projectRootPath: string, startDir: string): Promise<void> {
   it('should return a valid path', async () => {

--- a/test/helpers/rebuild.ts
+++ b/test/helpers/rebuild.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 type ExpectRebuildOptions = {
   buildType?: string;
   metaShouldExist?: boolean;
-}
+};
 
 export async function expectNativeModuleToBeRebuilt(
   basePath: string,

--- a/test/module-type-node-pre-gyp.ts
+++ b/test/module-type-node-pre-gyp.ts
@@ -29,7 +29,7 @@ describe('node-pre-gyp', function () {
       const nodePreGyp = new NodePreGyp(rebuilder, modulePath);
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(nodePreGyp.nodeAPI.getNapiVersion((await nodePreGyp.getSupportedNapiVersions())!)).to.equal(3);
-      expect(await nodePreGyp.getNodePreGypRuntimeArgs()).to.deep.equal([])
+      expect(await nodePreGyp.getNodePreGypRuntimeArgs()).to.deep.equal([]);
     });
 
     it('should not fail running node-pre-gyp', async () => {
@@ -57,7 +57,7 @@ describe('node-pre-gyp', function () {
     if (process.platform === 'win32') {
       alternativeArch = rebuilderArgs.arch === 'x64' ? 'ia32' : 'x64';
     } else {
-      alternativeArch = rebuilderArgs.arch === 'arm64' ? 'x64' : 'arm64'
+      alternativeArch = rebuilderArgs.arch === 'arm64' ? 'x64' : 'arm64';
     }
 
     rebuilder = new Rebuilder({ ...rebuilderArgs, arch: alternativeArch });

--- a/test/module-type-prebuild-install.ts
+++ b/test/module-type-prebuild-install.ts
@@ -32,7 +32,7 @@ describe('prebuild-install', () => {
       expect(await prebuildInstall.getPrebuildInstallRuntimeArgs()).to.deep.equal([
         '--runtime=napi',
         `--target=3`,
-      ])
+      ]);
     });
 
     it('should not fail running prebuild-install', async function () {

--- a/test/rebuild-napibuildversion.ts
+++ b/test/rebuild-napibuildversion.ts
@@ -17,21 +17,21 @@ describe('rebuild with napi_build_versions in binary config', async function () 
   const napiBuildVersionSpecificPath = (arch: string, libc: string) => path.resolve(testModulePath, `node_modules/sqlite3/lib/binding/napi-v${ napiBuildVersion }-${ process.platform }-${ libc }-${ arch }/node_sqlite3.node`);
 
   before(async () => {
-    await resetTestModule(testModulePath, true, 'napi-build-version')
+    await resetTestModule(testModulePath, true, 'napi-build-version');
     // Forcing `msvs_version` needed in order for `arm64` `win32` binary to be built
-    process.env.GYP_MSVS_VERSION = process.env.GYP_MSVS_VERSION ?? "2019"
+    process.env.GYP_MSVS_VERSION = process.env.GYP_MSVS_VERSION ?? "2019";
   });
   after(() => cleanupTestModule(testModulePath));
 
   // https://github.com/electron/rebuild/issues/554
-  const archs = ['x64', 'arm64']
+  const archs = ['x64', 'arm64'];
   for (const arch of archs) {
     it(`${ arch } arch should have rebuilt binary with 'napi_build_versions' array and 'libc' provided`, async () => {
-      const libc = await detectLibc.family() || 'unknown'
-      const binaryPath = napiBuildVersionSpecificPath(arch, libc)
+      const libc = await detectLibc.family() || 'unknown';
+      const binaryPath = napiBuildVersionSpecificPath(arch, libc);
       
       if (await fs.pathExists(binaryPath)) {
-        fs.removeSync(binaryPath)
+        fs.removeSync(binaryPath);
       }
       expect(await fs.pathExists(binaryPath)).to.be.false;
 

--- a/test/rebuild-yarnworkspace.ts
+++ b/test/rebuild-yarnworkspace.ts
@@ -13,7 +13,7 @@ describe('rebuild for yarn workspace', function() {
 
   describe('core behavior', () => {
     before(async () => {
-      await resetTestModule(testModulePath, true, 'workspace-test')
+      await resetTestModule(testModulePath, true, 'workspace-test');
       const projectRootPath = await getProjectRootPath(path.join(testModulePath, 'workspace-test', 'child-workspace'));
 
       await rebuild({


### PR DESCRIPTION
Adding eslint rule to enforce semicolons and fixing related lines/errors

Created this PR due to this comment: https://github.com/electron/rebuild/pull/1153#discussion_r1775646121

Note: `"semi": "off"` is needed as `"@typescript-eslint/semi": "error",` supersedes `semi` and having both as `error` results in duplicated errors for each lint line. Ref: https://stackoverflow.com/a/72341604/3498974