### PR TITLE
fix: allow using forks for prebuilt modules

### DIFF
--- a/src/module-type/index.ts
+++ b/src/module-type/index.ts
@@ -58,16 +58,18 @@ export class NativeModule {
    * Search dependencies for package using either `packageName` or
    * `@namespace/packageName` in the case of forks.
    */
-  async findPackageInDependencies(packageName: string): Promise<string | null> {
-    const dependencies = await this.packageJSONFieldWithDefault('dependencies', {});
+  async findPackageInDependencies(packageName: string, packageProperty = 'dependencies'): Promise<string | null> {
+    const dependencies = await this.packageJSONFieldWithDefault(packageProperty, {});
     if (typeof dependencies !== 'object') return null;
-    for (const dependency of Object.keys(dependencies)) {
-      // Directly using package
-      if (dependency === packageName) return dependency;
-      // Using possible forked package
-      if (dependency.endsWith(`/${packageName}`)) return dependency;
-    }
-    return null;
+
+    // Look for direct dependency match
+    // eslint-disable-next-line no-prototype-builtins
+    if (dependencies.hasOwnProperty(packageName)) return packageName;
+
+    const forkedPackage = Object.keys(dependencies).find(dependency =>
+      dependency.startsWith('@') && dependency.endsWith(`/${packageName}`));
+
+    return forkedPackage || null;
   }
 }
 

--- a/src/module-type/index.ts
+++ b/src/module-type/index.ts
@@ -53,6 +53,22 @@ export class NativeModule {
 
     return binary?.napi_versions;
   }
+
+  /**
+   * Search dependencies for package using either `packageName` or
+   * `@namespace/packageName` in the case of forks.
+   */
+  async findPackageInDependencies(packageName: string): Promise<string | null> {
+    const dependencies = await this.packageJSONFieldWithDefault('dependencies', {});
+    if (typeof dependencies !== 'object') return null;
+    for (const dependency of Object.keys(dependencies)) {
+      // Directly using package
+      if (dependency === packageName) return dependency;
+      // Using possible forked package
+      if (dependency.endsWith(`/${packageName}`)) return dependency;
+    }
+    return null;
+  }
 }
 
 export async function locateBinary(basePath: string, suffix: string): Promise<string | null> {

--- a/src/module-type/node-pre-gyp.ts
+++ b/src/module-type/node-pre-gyp.ts
@@ -7,13 +7,17 @@ const d = debug('electron-rebuild');
 
 export class NodePreGyp extends NativeModule {
   async usesTool(): Promise<boolean> {
-    const dependencies = await this.packageJSONFieldWithDefault('dependencies', {});
-    // eslint-disable-next-line no-prototype-builtins
-    return dependencies.hasOwnProperty('@mapbox/node-pre-gyp');
+    const packageName = await this.findPackageInDependencies('node-pre-gyp');
+    return !!packageName;
   }
 
   async locateBinary(): Promise<string | null> {
-    return locateBinary(this.modulePath, 'node_modules/@mapbox/node-pre-gyp/bin/node-pre-gyp');
+    const packageName = await this.findPackageInDependencies('node-pre-gyp');
+    if (!packageName) return null;
+    return locateBinary(
+      this.modulePath,
+      `node_modules/${packageName}/bin/node-pre-gyp`
+    );
   }
 
   async run(nodePreGypPath: string): Promise<void> {

--- a/src/module-type/prebuild-install.ts
+++ b/src/module-type/prebuild-install.ts
@@ -8,13 +8,17 @@ const d = debug('electron-rebuild');
 
 export class PrebuildInstall extends NativeModule {
   async usesTool(): Promise<boolean> {
-    const dependencies = await this.packageJSONFieldWithDefault('dependencies', {});
-    // eslint-disable-next-line no-prototype-builtins
-    return dependencies.hasOwnProperty('prebuild-install');
+    const packageName = await this.findPackageInDependencies('prebuild-install');
+    return !!packageName;
   }
 
   async locateBinary(): Promise<string | null> {
-    return locateBinary(this.modulePath, 'node_modules/prebuild-install/bin.js');
+    const packageName = await this.findPackageInDependencies('prebuild-install');
+    if (!packageName) return null;
+    return locateBinary(
+      this.modulePath,
+      `node_modules/${packageName}/bin.js`
+    );
   }
 
   async run(prebuildInstallPath: string): Promise<void> {

--- a/src/module-type/prebuildify.ts
+++ b/src/module-type/prebuildify.ts
@@ -32,14 +32,11 @@ export function determineNativePrebuildExtension(arch: string): string {
 
 export class Prebuildify extends NativeModule {
   async usesTool(): Promise<boolean> {
-    const devDependencies = await this.packageJSONFieldWithDefault('devDependencies', {});
-    // eslint-disable-next-line no-prototype-builtins
-    return devDependencies.hasOwnProperty('prebuildify');
+    const packageName = await this.findPackageInDependencies('prebuildify', 'devDependencies');
+    return !!packageName;
   }
 
   async findPrebuiltModule(): Promise<boolean> {
-    const nodeArch = getNodeArch(this.rebuilder.arch, process.config.variables as ConfigVariables);
-
     d(`Checking for prebuilds for "${this.moduleName}"`);
 
     const prebuildsDir = path.join(this.modulePath, 'prebuilds');
@@ -49,6 +46,7 @@ export class Prebuildify extends NativeModule {
     }
 
     const prebuiltModuleDir = path.join(prebuildsDir, `${this.rebuilder.platform}-${determineNativePrebuildArch(nodeArch)}`);
+    const nodeArch = getNodeArch(this.rebuilder.arch, process.config.variables as ConfigVariables);
     const nativeExt = determineNativePrebuildExtension(nodeArch);
     const electronNapiModuleFilename = path.join(prebuiltModuleDir, `electron.napi.${nativeExt}`);
     const nodejsNapiModuleFilename = path.join(prebuiltModuleDir, `node.napi.${nativeExt}`);

--- a/src/module-type/prebuildify.ts
+++ b/src/module-type/prebuildify.ts
@@ -45,8 +45,8 @@ export class Prebuildify extends NativeModule {
       return false;
     }
 
-    const prebuiltModuleDir = path.join(prebuildsDir, `${this.rebuilder.platform}-${determineNativePrebuildArch(nodeArch)}`);
     const nodeArch = getNodeArch(this.rebuilder.arch, process.config.variables as ConfigVariables);
+    const prebuiltModuleDir = path.join(prebuildsDir, `${this.rebuilder.platform}-${determineNativePrebuildArch(nodeArch)}`);
     const nativeExt = determineNativePrebuildExtension(nodeArch);
     const electronNapiModuleFilename = path.join(prebuiltModuleDir, `electron.napi.${nativeExt}`);
     const nodejsNapiModuleFilename = path.join(prebuiltModuleDir, `node.napi.${nativeExt}`);

--- a/test/fixture/forked-module-test/package.json
+++ b/test/fixture/forked-module-test/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "forked-module-test",
+  "productName": "Native App",
+  "version": "1.0.0",
+  "description": "",
+  "main": "src/index.js",
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@electron/node-pre-gyp": "npm:@mapbox/node-pre-gyp@1.0.11",
+    "@electron/prebuild-install": "npm:prebuild-install@7.1.2"
+  },
+  "devDependencies": {
+    "@electron/prebuildify": "npm:prebuildify@6.0.1"
+  }
+}

--- a/test/fixture/native-app1/package.json
+++ b/test/fixture/native-app1/package.json
@@ -23,8 +23,7 @@
     "level": "6.0.0",
     "native-hello-world": "2.0.0",
     "ref-napi": "1.4.2",
-    "sqlite3": "5.1.6",
-    "@electron/node-pre-gyp": "npm:@mapbox/node-pre-gyp@1.0.11"
+    "sqlite3": "5.1.6"
   },
   "optionalDependencies": {
     "bcrypt": "5.0.0"

--- a/test/fixture/native-app1/package.json
+++ b/test/fixture/native-app1/package.json
@@ -23,7 +23,8 @@
     "level": "6.0.0",
     "native-hello-world": "2.0.0",
     "ref-napi": "1.4.2",
-    "sqlite3": "5.1.6"
+    "sqlite3": "5.1.6",
+    "@electron/node-pre-gyp": "npm:@mapbox/node-pre-gyp@1.0.11"
   },
   "optionalDependencies": {
     "bcrypt": "5.0.0"

--- a/test/helpers/module-setup.ts
+++ b/test/helpers/module-setup.ts
@@ -1,8 +1,11 @@
+import debug from 'debug';
 import crypto from 'crypto';
 import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
 import { spawn } from '@malept/cross-spawn-promise';
+
+const d = debug('electron-rebuild');
 
 const originalGypMSVSVersion: string | undefined = process.env.GYP_MSVS_VERSION;
 const TIMEOUT_IN_MINUTES = process.platform === 'win32' ? 5 : 2;
@@ -23,6 +26,7 @@ const testModuleTmpPath = fs.mkdtempSync(path.resolve(os.tmpdir(), 'e-r-test-mod
 export async function resetTestModule(testModulePath: string, installModules = true, fixtureName = 'native-app1'): Promise<void> {
   const oneTimeModulePath = path.resolve(testModuleTmpPath, `${crypto.createHash('SHA1').update(testModulePath).digest('hex')}-${fixtureName}-${installModules}`);
   if (!await fs.pathExists(oneTimeModulePath)) {
+    d(`creating test module '%s' in %s`, fixtureName, oneTimeModulePath);
     await fs.mkdir(oneTimeModulePath, { recursive: true });
     await fs.copy(path.resolve(__dirname, `../../test/fixture/${ fixtureName }`), oneTimeModulePath);
     if (installModules) {

--- a/test/module-type-node-pre-gyp.ts
+++ b/test/module-type-node-pre-gyp.ts
@@ -83,9 +83,8 @@ describe('node-pre-gyp', function () {
   });
 
   it('should find module fork', async () => {
-    await resetTestModule(testModulePath, false, 'forked-module-test');
     const rebuilder = new Rebuilder(rebuilderArgs);
-    const nodePreGyp = new NodePreGyp(rebuilder, testModulePath);
+    const nodePreGyp = new NodePreGyp(rebuilder, path.join(__dirname, 'fixture', 'forked-module-test'));
     expect(await nodePreGyp.usesTool()).to.equal(true);
   });
 });

--- a/test/module-type-node-pre-gyp.ts
+++ b/test/module-type-node-pre-gyp.ts
@@ -24,6 +24,13 @@ describe('node-pre-gyp', function () {
   after(async () => await cleanupTestModule(testModulePath));
 
   describe('Node-API support', function() {
+    it('should find fork of node-pre-gyp', async () => {
+      const rebuilder = new Rebuilder(rebuilderArgs);
+      // The test module contains a dependency aliasing 'node-pre-gyp'
+      const nodePreGyp = new NodePreGyp(rebuilder, testModulePath);
+      expect(await nodePreGyp.usesTool()).to.equal(true);
+    });
+
     it('should find correct napi version and select napi args', async () => {
       const rebuilder = new Rebuilder(rebuilderArgs);
       const nodePreGyp = new NodePreGyp(rebuilder, modulePath);

--- a/test/module-type-node-pre-gyp.ts
+++ b/test/module-type-node-pre-gyp.ts
@@ -24,13 +24,6 @@ describe('node-pre-gyp', function () {
   after(async () => await cleanupTestModule(testModulePath));
 
   describe('Node-API support', function() {
-    it('should find fork of node-pre-gyp', async () => {
-      const rebuilder = new Rebuilder(rebuilderArgs);
-      // The test module contains a dependency aliasing 'node-pre-gyp'
-      const nodePreGyp = new NodePreGyp(rebuilder, testModulePath);
-      expect(await nodePreGyp.usesTool()).to.equal(true);
-    });
-
     it('should find correct napi version and select napi args', async () => {
       const rebuilder = new Rebuilder(rebuilderArgs);
       const nodePreGyp = new NodePreGyp(rebuilder, modulePath);
@@ -87,5 +80,12 @@ describe('node-pre-gyp', function () {
     rebuilder = new Rebuilder({ ...rebuilderArgs, platform: alternativePlatform });
     nodePreGyp = new NodePreGyp(rebuilder, modulePath);
     expect(await nodePreGyp.findPrebuiltModule()).to.equal(true);
+  });
+
+  it('should find module fork', async () => {
+    await resetTestModule(testModulePath, false, 'forked-module-test');
+    const rebuilder = new Rebuilder(rebuilderArgs);
+    const nodePreGyp = new NodePreGyp(rebuilder, testModulePath);
+    expect(await nodePreGyp.usesTool()).to.equal(true);
   });
 });

--- a/test/module-type-prebuild-install.ts
+++ b/test/module-type-prebuild-install.ts
@@ -75,9 +75,8 @@ describe('prebuild-install', () => {
   });
 
   it('should find module fork', async () => {
-    await resetTestModule(testModulePath, false, 'forked-module-test');
     const rebuilder = new Rebuilder(rebuilderArgs);
-    const nodePreGyp = new PrebuildInstall(rebuilder, testModulePath);
-    expect(await nodePreGyp.usesTool()).to.equal(true);
+    const prebuildInstall = new PrebuildInstall(rebuilder, path.join(__dirname, 'fixture', 'forked-module-test'));
+    expect(await prebuildInstall.usesTool()).to.equal(true);
   });
 });

--- a/test/module-type-prebuild-install.ts
+++ b/test/module-type-prebuild-install.ts
@@ -73,4 +73,11 @@ describe('prebuild-install', () => {
       expect(await prebuild.findPrebuiltModule()).to.equal(true);
     });
   });
+
+  it('should find module fork', async () => {
+    await resetTestModule(testModulePath, false, 'forked-module-test');
+    const rebuilder = new Rebuilder(rebuilderArgs);
+    const nodePreGyp = new PrebuildInstall(rebuilder, testModulePath);
+    expect(await nodePreGyp.usesTool()).to.equal(true);
+  });
 });

--- a/test/module-type-prebuildify.ts
+++ b/test/module-type-prebuildify.ts
@@ -133,4 +133,10 @@ describe('prebuildify', () => {
       expect(await prebuildify.findPrebuiltModule()).to.equal(true);
     });
   });
+
+  it('should find module fork', async () => {
+    const rebuilder = createRebuilder();
+    const prebuildify = new Prebuildify(rebuilder, path.join(__dirname, 'fixture', 'forked-module-test'));
+    expect(await prebuildify.usesTool()).to.equal(true);
+  });
 });


### PR DESCRIPTION
It may sometimes be necessary to fork a prebuilt module package to fix an issue. In such cases, the rebuilder can miss prebuilt modules, forcing them to be built from source.

To avoid this, the module rebuilders will now also search for possible forked packages.
- `@mapbox/node-pre-gyp` may instead be `node-pre-gyp` or `@namespace/node-pre-gyp`
- `prebuild-install` may instead be `@namespace/prebuild-install`
- `prebuilds` may instead be `@namespace/prebuilds`