### PR TITLE
build: bump @electron/rebuild to 4.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "detect-libc": "^2.0.1",
     "fs-extra": "^10.0.0",
     "got": "^11.7.0",
-    "node-abi": "^3.45.0",
+    "node-abi": "^4.4.0",
     "node-api-version": "^0.2.0",
     "ora": "^5.1.0",
     "read-binary-file-arch": "^1.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2391,12 +2391,12 @@ negotiator@^0.6.3:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
-node-abi@^3.45.0:
-  version "3.45.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.45.0.tgz#f568f163a3bfca5aacfce1fbeee1fa2cc98441f5"
-  integrity sha512-iwXuFrMAcFVi/ZoZiqq8BzAdsLw9kxDfTC0HMyjXfSL/6CSDAGD5UmR7azrAgWV1zKYq7dUUMj4owusBWKLsiQ==
+node-abi@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-4.4.0.tgz#f17a2880a556337030a02b7f92e308946cdbbfc9"
+  integrity sha512-+sBEWs/HZ3ZDBtPSPKfYndkTF9ebr1BJm/z2TBDJj/upiOx9J6BeGXRtFyOXz1r6vUqzsCRM5pUr+K83i64agg==
   dependencies:
-    semver "^7.3.5"
+    semver "^7.6.3"
 
 node-api-version@^0.2.0:
   version "0.2.0"
@@ -2846,6 +2846,11 @@ semver@^7.2.1, semver@^7.3.2, semver@^7.3.5:
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^7.6.3:
+  version "7.7.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.1.tgz#abd5098d82b18c6c81f6074ff2647fd3e7220c9f"
+  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
 
 serialize-error@^7.0.1:
   version "7.0.1"


### PR DESCRIPTION
This PR updates rebuild to use node-abi 4.x.x and higher - node-abi was bumped to 4.x.x during our Node 22 upgrade process, and is now needed to pull in newer versions of Electron.