### PR TITLE
ci: remove unused matrix exclude

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,6 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
-        exclude:
-          - os: windows-latest
-            node-version: '14.16'
     runs-on: "${{ matrix.os }}"
     env:
       GYP_MSVS_VERSION: '2022'


### PR DESCRIPTION
We no longer support Node.js 14 and don't test on it so this exclude is a no-op.