### PR TITLE
refactor: use timers/promises

### DIFF
--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1,11 +1,9 @@
+import { setTimeout as sleep } from 'node:timers/promises';
+
 import debug from 'debug';
 import got from 'got';
 
 const d = debug('electron-rebuild');
-
-function sleep(n: number) {
-  return new Promise(r => setTimeout(r, n));
-}
 
 export async function fetch<T extends 'buffer' | 'text', RT = T extends 'buffer' ? Buffer : string>(url: string, responseType: T, retries = 3): Promise<RT> {
   if (retries === 0) throw new Error('Failed to fetch a clang resource, run with DEBUG=electron-rebuild for more information');


### PR DESCRIPTION
Just swapping this in favor of the Node.js builtin.