### PR TITLE
ci: bump codecov/codecov-action to 5.5.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
           yarn run coverage
           yarn run coverage:report
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+        uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 # v5.5.0
         with:
           files: ./coverage.lcov
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This is needed to pick up a fix so that the action works with org-wide SHA pinning enforced for GHA.